### PR TITLE
[BACK-2216] Add demo clinic patient on new clinic creation

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,37 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main clinic.go"
+  delay = 2000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = ["Dockerfile"]
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", "test"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,17 @@ WORKDIR /go/src/github.com/tidepool-org/clinic
 RUN adduser -D tidepool && \
     chown -R tidepool /go/src/github.com/tidepool-org/clinic
 USER tidepool
+RUN go install github.com/cosmtrek/air@latest
+COPY --chown=tidepool . .
+RUN ./build.sh
+CMD ["air"]
+
+# Production
+FROM golang:1.16-alpine AS production
+WORKDIR /go/src/github.com/tidepool-org/clinic
+RUN adduser -D tidepool && \
+    chown -R tidepool /go/src/github.com/tidepool-org/clinic
+USER tidepool
 COPY --chown=tidepool . .
 RUN ./build.sh
 CMD ["./dist/clinic"]

--- a/clinics/creator/creator.go
+++ b/clinics/creator/creator.go
@@ -3,6 +3,7 @@ package creator
 import (
 	"context"
 	"fmt"
+
 	"github.com/kelseyhightower/envconfig"
 	"github.com/tidepool-org/clinic/clinicians"
 	"github.com/tidepool-org/clinic/clinics"
@@ -17,7 +18,7 @@ const (
 )
 
 type Config struct {
-	ClinicDemoPatientUserId string `envconfig:"CLINIC_DEMO_PATIENT_USER_ID"`
+	ClinicDemoPatientUserId string `envconfig:"DEMO_CLINIC_USER_ID"`
 }
 
 func NewConfig() (*Config, error) {
@@ -53,6 +54,7 @@ type Params struct {
 	CliniciansRepository *clinicians.Repository
 	Config               *Config
 	DbClient             *mongo.Client
+	PatientsService      patients.Service
 	ShareCodeGenerator   clinics.ShareCodeGenerator
 	UserService          patients.UserService
 }
@@ -63,6 +65,7 @@ func NewCreator(cp Params) (Creator, error) {
 		cliniciansRepository: cp.CliniciansRepository,
 		config:               cp.Config,
 		dbClient:             cp.DbClient,
+		patientsService:      cp.PatientsService,
 		shareCodeGenerator:   cp.ShareCodeGenerator,
 		userService:          cp.UserService,
 	}, nil


### PR DESCRIPTION
See [BACK-2216]

This was already handled by Todd.  I just renamed the expected patient id env variable to `DEMO_CLINIC_USER_ID` to match what we use in other services, and added the `PatientsService` which was missing in the creator context.

I also updated the Dockerfile to use [air](https://github.com/cosmtrek/air) to allow live rebuilding to work in the local Tilt stack.

Note: I've opened this PR against the `hourlystats` branch.  Feel free to change the base to `master` if it's preferable.

[BACK-2216]: https://tidepool.atlassian.net/browse/BACK-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ