### PR TITLE
[BACK-2235] Set newly created clinics `IsMigrated` property to true

### DIFF
--- a/clinics/creator/creator.go
+++ b/clinics/creator/creator.go
@@ -97,6 +97,10 @@ func (c *creator) CreateClinic(ctx context.Context, create *CreateClinic) (*clin
 		// Set initial admins
 		create.Clinic.AddAdmin(create.CreatorUserId)
 
+		// Set new clinic migration status to true.
+		// Only clinics created via `EnableNewClinicExperience` handler should be subject to initial clinician patient migration
+		create.Clinic.IsMigrated = true
+
 		// Add the clinic to the collection
 		clinic, err := c.createClinicObject(sessionCtx, create)
 		if err != nil {


### PR DESCRIPTION
A number of clinician operations will only work if `clinic.IsMigrated` is true.  This was intended to only apply to empty clinics created for clinician migrations.

For newly clinics created, we set this to true by default so that clinician operations (invite, delete, etc) for the clinic are allowed. 