### PR TITLE
use make for dependency resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,14 @@ generate:
 	cd client && go generate ./...
 
 # Generate linkerd service profile
-.PHONY: service-profile
-service-profile: generate
-	mkdir -p service-profile
-	openapi-filter -f Confirmations --checkTags spec/clinic.v1.yaml service-profile/clinic.v1.yaml
+service-profile/profile.yaml: service-profile/clinic.v1.yaml service-profile
 	linkerd profile --ignore-cluster --open-api service-profile/clinic.v1.yaml clinic > service-profile/profile.yaml
+
+service-profile/clinic.v1.yaml: generate service-profile
+	openapi-filter -f Confirmations --checkTags spec/clinic.v1.yaml service-profile/clinic.v1.yaml
+
+service-profile:
+	mkdir -p service-profile
 
 # Set flags
 .PHONY: go-flags


### PR DESCRIPTION
One of make's strengths is its ability to manage dependencies. By creating recipes for each file to be created, installed, or generated, and listing the prerequisites for each of those targets, make can determine if they need to be regenerated, and will handle doing so in the correct order, and where possible, in parallel (if configured).
