### PR TITLE
[ORCA-87] Allow backend services to fetch a clinic by share code

### DIFF
--- a/auth/authorizer_test.go
+++ b/auth/authorizer_test.go
@@ -92,6 +92,19 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("allows backend services to fetch clinics by share code /v1/clinics/share_code/acmeclinic", func() {
+			input := map[string]interface{}{
+				"path":   []string{"v1", "clinics", "share_code", "acmeclinic"},
+				"method": "GET",
+				"auth": map[string]interface{}{
+					"subjectId":    "orca",
+					"serverAccess": true,
+				},
+			}
+			err := authorizer.EvaluatePolicy(context.Background(), input)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("allows shoreline to list clinics for a given user id", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "patients", "12345", "clinics"},

--- a/auth/policy.rego
+++ b/auth/policy.rego
@@ -142,12 +142,12 @@ allow {
   input.path = ["v1", "clinics", "share_code", _]
 }
 
-# Allow backend services to fetch a clinic by id
-# GET /v1/clinics/:clinicId
+# Allow backend services to fetch clinics by share code
+# GET /v1/clinics/share_code/:shareCode
 allow {
   is_backend_service
   input.method == "GET"
-  input.path = ["v1", "clinics", _]
+  input.path = ["v1", "clinics", "share_code", _]
 }
 
 # Allow currently authenticated clinician to update clinic


### PR DESCRIPTION
For the ORCA (admin tool) rebuild ([ORCA-87]), I'm unable to fetch a clinic via share code.
I believe this should be all that's needed to unblock me.

I also removed a duplicated permissions block in `policy.rego`
