### PR TITLE
[BACK-2834] Create clinic patient count settings

### DIFF
--- a/api/clinics.go
+++ b/api/clinics.go
@@ -66,9 +66,6 @@ func (h *Handler) CreateClinic(ec echo.Context) error {
 	// Only clinics created via `EnableNewClinicExperience` handler should be subject to initial clinician patient migration
 	clinic.IsMigrated = true
 
-	// Set new clinic patient count to zero
-	clinic.PatientCount = &clinics.PatientCount{PatientCount: 0}
-
 	create := manager.CreateClinic{
 		Clinic:            clinic,
 		CreatorUserId:     authData.SubjectId,

--- a/api/mappers.go
+++ b/api/mappers.go
@@ -29,22 +29,26 @@ func NewClinic(c Clinic) *clinics.Clinic {
 		}
 	}
 
-	clinic := &clinics.Clinic{
-		Name:             &c.Name,
-		ClinicType:       clinicTypeToString(c.ClinicType),
-		ClinicSize:       clinicSizeToString(c.ClinicSize),
-		Address:          c.Address,
-		City:             c.City,
-		Country:          c.Country,
-		PostalCode:       c.PostalCode,
-		State:            c.State,
-		PhoneNumbers:     &phoneNumbers,
-		Website:          c.Website,
-		PreferredBgUnits: string(c.PreferredBgUnits),
-	}
+	clinic := clinics.NewClinic()
+	clinic.Name = &c.Name
+	clinic.ClinicType = clinicTypeToString(c.ClinicType)
+	clinic.ClinicSize = clinicSizeToString(c.ClinicSize)
+	clinic.Address = c.Address
+	clinic.City = c.City
+	clinic.Country = c.Country
+	clinic.PostalCode = c.PostalCode
+	clinic.State = c.State
+	clinic.PhoneNumbers = &phoneNumbers
+	clinic.Website = c.Website
+	clinic.PreferredBgUnits = string(c.PreferredBgUnits)
 	if c.Timezone != nil {
 		tz := string(*c.Timezone)
 		clinic.Timezone = &tz
+	}
+
+	// If outside US, then no patient count settings
+	if clinic.IsOUS() {
+		clinic.PatientCountSettings = nil
 	}
 
 	return clinic

--- a/clinics/clinics.go
+++ b/clinics/clinics.go
@@ -15,6 +15,9 @@ const (
 	DefaultMrnIdType           = "MRN"
 	WorkspaceIdTypeClinicId    = "clinicId"
 	WorkspaceIdTypeEHRSourceId = "ehrSourceId"
+
+	CountryCodeUS                                    = "US"
+	PatientCountSettingsHardLimitPatientCountDefault = 250
 )
 
 var (
@@ -99,6 +102,10 @@ type Clinic struct {
 	PatientCount            *PatientCount            `bson:"patientCount,omitempty"`
 }
 
+func (c Clinic) IsOUS() bool {
+	return c.Country != nil && *c.Country != CountryCodeUS
+}
+
 type EHRSettings struct {
 	Enabled        bool               `bson:"enabled"`
 	Provider       string             `bson:"provider"`
@@ -146,6 +153,12 @@ func (p PatientCount) IsValid() bool {
 	return p.PatientCount >= 0
 }
 
+func NewPatientCount() *PatientCount {
+	return &PatientCount{
+		PatientCount: 0,
+	}
+}
+
 type PatientCountSettings struct {
 	HardLimit *PatientCountLimit `bson:"hardLimit,omitempty"`
 	SoftLimit *PatientCountLimit `bson:"softLimit,omitempty"`
@@ -159,6 +172,14 @@ func (p PatientCountSettings) IsValid() bool {
 		return false
 	}
 	return true
+}
+
+func DefaultPatientCountSettings() *PatientCountSettings {
+	return &PatientCountSettings{
+		HardLimit: &PatientCountLimit{
+			PatientCount: PatientCountSettingsHardLimitPatientCountDefault,
+		},
+	}
 }
 
 type PatientCountLimit struct {
@@ -177,10 +198,10 @@ func (p PatientCountLimit) IsValid() bool {
 	return true
 }
 
-func NewClinic() Clinic {
-	return Clinic{
-		CreatedTime: time.Now(),
-		UpdatedTime: time.Now(),
+func NewClinic() *Clinic {
+	return &Clinic{
+		PatientCount:         NewPatientCount(),
+		PatientCountSettings: DefaultPatientCountSettings(),
 	}
 }
 

--- a/clinics/migration/migration.go
+++ b/clinics/migration/migration.go
@@ -3,6 +3,8 @@ package migration
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/tidepool-org/clinic/clinicians"
 	"github.com/tidepool-org/clinic/clinics"
 	"github.com/tidepool-org/clinic/clinics/manager"
@@ -10,7 +12,6 @@ import (
 	"github.com/tidepool-org/clinic/patients"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/fx"
-	"time"
 )
 
 const (
@@ -89,7 +90,7 @@ func (m *migrator) CreateEmptyClinic(ctx context.Context, userId string) (*clini
 	}
 
 	return m.clinicsCreator.CreateClinic(ctx, &manager.CreateClinic{
-		Clinic:        clinics.NewClinic(),
+		Clinic:        *clinics.NewClinic(),
 		CreatorUserId: userId,
 	})
 }

--- a/clinics/repo_test.go
+++ b/clinics/repo_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Clinics", func() {
 	})
 
 	Describe("GetPatientCountSettings", func() {
-		It("returns no patient count settings by default", func() {
+		It("returns patient count settings by default", func() {
 			clinic := clinicsTest.RandomClinic()
 			clinic, err := repo.Create(context.Background(), clinic)
 			Expect(err).ToNot(HaveOccurred())
@@ -41,7 +41,7 @@ var _ = Describe("Clinics", func() {
 
 			patientCountSettings, err := repo.GetPatientCountSettings(context.Background(), clinic.Id.Hex())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(patientCountSettings).To(BeNil())
+			Expect(patientCountSettings).To(Equal(clinics.DefaultPatientCountSettings()))
 		})
 
 		It("returns patient count settings when set", func() {
@@ -106,7 +106,7 @@ var _ = Describe("Clinics", func() {
 	})
 
 	Describe("GetPatientCount", func() {
-		It("returns no patient count by default", func() {
+		It("returns patient count by default", func() {
 			clinic := clinicsTest.RandomClinic()
 			clinic, err := repo.Create(context.Background(), clinic)
 			Expect(err).ToNot(HaveOccurred())
@@ -114,7 +114,7 @@ var _ = Describe("Clinics", func() {
 
 			patientCount, err := repo.GetPatientCount(context.Background(), clinic.Id.Hex())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(patientCount).To(BeNil())
+			Expect(patientCount).To(Equal(clinics.NewPatientCount()))
 		})
 
 		It("returns patient count when set", func() {

--- a/clinics/test/clinic.go
+++ b/clinics/test/clinic.go
@@ -1,13 +1,14 @@
 package test
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/jaswdr/faker"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/tidepool-org/clinic/clinics"
 	"github.com/tidepool-org/clinic/clinics/manager"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"math/rand"
-	"time"
 )
 
 var (
@@ -36,39 +37,39 @@ func RandomClinic() *clinics.Clinic {
 	admins := []string{Faker.UUID().V4()}
 	id := RandomObjectId()
 
-	return &clinics.Clinic{
-		Id:                 &id,
-		Address:            strp(Faker.Address().Address()),
-		City:               strp(Faker.Address().City()),
-		ClinicType:         strp(Faker.RandomStringElement([]string{"Diabetes Clinic", "Hospital"})),
-		ClinicSize:         strp(Faker.RandomStringElement([]string{"0-100", "100-1000"})),
-		Country:            strp(Faker.Address().Country()),
-		Name:               strp(Faker.Company().Name()),
-		PatientTags:        RandomTags(3),
-		PostalCode:         strp(Faker.Address().PostCode()),
-		State:              strp(Faker.Address().State()),
-		CanonicalShareCode: strp(shareCode),
-		Website:            strp(Faker.Internet().Domain()),
-		ShareCodes:         &shareCodes,
-		Admins:             &admins,
-		CreatedTime:        Faker.Time().Time(time.Now()),
-		UpdatedTime:        Faker.Time().Time(time.Now()),
-		IsMigrated:         false,
-		EHRSettings: &clinics.EHRSettings{
-			Enabled:  true,
-			Provider: "xealth",
-			Facility: &clinics.EHRFacility{
-				Name: Faker.Company().Name(),
-			},
-			ProcedureCodes: clinics.EHRProcedureCodes{
-				EnableSummaryReports:          strp("12345"),
-				DisableSummaryReports:         strp("23456"),
-				CreateAccount:                 strp("34567"),
-				CreateAccountAndEnableReports: strp("45678"),
-			},
-			SourceId: Faker.UUID().V4(),
+	clinic := clinics.NewClinic()
+	clinic.Id = &id
+	clinic.Address = strp(Faker.Address().Address())
+	clinic.City = strp(Faker.Address().City())
+	clinic.ClinicType = strp(Faker.RandomStringElement([]string{"Diabetes Clinic", "Hospital"}))
+	clinic.ClinicSize = strp(Faker.RandomStringElement([]string{"0-100", "100-1000"}))
+	clinic.Country = strp(Faker.Address().Country())
+	clinic.Name = strp(Faker.Company().Name())
+	clinic.PatientTags = RandomTags(3)
+	clinic.PostalCode = strp(Faker.Address().PostCode())
+	clinic.State = strp(Faker.Address().State())
+	clinic.CanonicalShareCode = strp(shareCode)
+	clinic.Website = strp(Faker.Internet().Domain())
+	clinic.ShareCodes = &shareCodes
+	clinic.Admins = &admins
+	clinic.CreatedTime = Faker.Time().Time(time.Now())
+	clinic.UpdatedTime = Faker.Time().Time(time.Now())
+	clinic.IsMigrated = false
+	clinic.EHRSettings = &clinics.EHRSettings{
+		Enabled:  true,
+		Provider: "xealth",
+		Facility: &clinics.EHRFacility{
+			Name: Faker.Company().Name(),
 		},
+		ProcedureCodes: clinics.EHRProcedureCodes{
+			EnableSummaryReports:          strp("12345"),
+			DisableSummaryReports:         strp("23456"),
+			CreateAccount:                 strp("34567"),
+			CreateAccountAndEnableReports: strp("45678"),
+		},
+		SourceId: Faker.UUID().V4(),
 	}
+	return clinic
 }
 
 func RandomTags(count int) []clinics.PatientTag {


### PR DESCRIPTION
- Use common function for creating a new clinic
- New clinic uses default patient count and patient count settings
- Update tests
- https://tidepool.atlassian.net/browse/BACK-2834

Note: Based off of `BACK-2693-enforce-patient-count-limit` feature branch, a required predecessor. Will either merge all at once or merge predecessor first and rebase this off `master`.