### PR TITLE
[BACK-2973] Update patient count settings when clinic country changes

### DIFF
--- a/api/mappers.go
+++ b/api/mappers.go
@@ -18,7 +18,17 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func NewClinicWithDefaults(c Clinic) *clinics.Clinic {
+	clinic := mapClinic(c, clinics.NewClinicWithDefaults())
+	clinic.UpdatePatientCountSettingsForCountry()
+	return clinic
+}
+
 func NewClinic(c Clinic) *clinics.Clinic {
+	return mapClinic(c, clinics.NewClinic())
+}
+
+func mapClinic(c Clinic, clinic *clinics.Clinic) *clinics.Clinic {
 	var phoneNumbers []clinics.PhoneNumber
 	if c.PhoneNumbers != nil {
 		for _, n := range *c.PhoneNumbers {
@@ -29,7 +39,6 @@ func NewClinic(c Clinic) *clinics.Clinic {
 		}
 	}
 
-	clinic := clinics.NewClinic()
 	clinic.Name = &c.Name
 	clinic.ClinicType = clinicTypeToString(c.ClinicType)
 	clinic.ClinicSize = clinicSizeToString(c.ClinicSize)
@@ -44,11 +53,6 @@ func NewClinic(c Clinic) *clinics.Clinic {
 	if c.Timezone != nil {
 		tz := string(*c.Timezone)
 		clinic.Timezone = &tz
-	}
-
-	// If outside US, then no patient count settings
-	if clinic.IsOUS() {
-		clinic.PatientCountSettings = nil
 	}
 
 	return clinic

--- a/clinics/clinics.go
+++ b/clinics/clinics.go
@@ -198,11 +198,26 @@ func (p PatientCountLimit) IsValid() bool {
 	return true
 }
 
+func NewClinicWithDefaults() *Clinic {
+	c := NewClinic()
+	c.PatientCount = NewPatientCount()
+	c.PatientCountSettings = DefaultPatientCountSettings()
+	return c
+}
+
 func NewClinic() *Clinic {
-	return &Clinic{
-		PatientCount:         NewPatientCount(),
-		PatientCountSettings: DefaultPatientCountSettings(),
+	return &Clinic{}
+}
+
+func (c *Clinic) UpdatePatientCountSettingsForCountry() bool {
+	if isOUS := c.IsOUS(); isOUS && c.PatientCountSettings != nil {
+		c.PatientCountSettings = nil
+		return true
+	} else if !isOUS && c.PatientCountSettings == nil {
+		c.PatientCountSettings = DefaultPatientCountSettings()
+		return true
 	}
+	return false
 }
 
 func (c *Clinic) HasAllRequiredFields() bool {

--- a/clinics/migration/migration.go
+++ b/clinics/migration/migration.go
@@ -90,7 +90,7 @@ func (m *migrator) CreateEmptyClinic(ctx context.Context, userId string) (*clini
 	}
 
 	return m.clinicsCreator.CreateClinic(ctx, &manager.CreateClinic{
-		Clinic:        *clinics.NewClinic(),
+		Clinic:        *clinics.NewClinicWithDefaults(),
 		CreatorUserId: userId,
 	})
 }

--- a/clinics/test/clinic.go
+++ b/clinics/test/clinic.go
@@ -37,7 +37,7 @@ func RandomClinic() *clinics.Clinic {
 	admins := []string{Faker.UUID().V4()}
 	id := RandomObjectId()
 
-	clinic := clinics.NewClinic()
+	clinic := clinics.NewClinicWithDefaults()
 	clinic.Id = &id
 	clinic.Address = strp(Faker.Address().Address())
 	clinic.City = strp(Faker.Address().City())

--- a/integration/xealth_test.go
+++ b/integration/xealth_test.go
@@ -5,6 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
 	"github.com/TwiN/deepmerge"
 	"github.com/labstack/echo/v4"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,13 +25,6 @@ import (
 	xealthTest "github.com/tidepool-org/clinic/xealth/test"
 	"github.com/tidepool-org/clinic/xealth_client"
 	"go.uber.org/fx"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"os"
-	"sync"
-	"time"
 )
 
 const (
@@ -302,7 +303,7 @@ var _ = Describe("Xealth Integration Test", Ordered, func() {
 			Expect(response.Programs).To(HaveLen(1))
 
 			program := response.Programs[0]
-			today := time.Now().Format(time.DateOnly)
+			today := time.Now().UTC().Format(time.DateOnly)
 
 			// Last upload should be set to the summary last updated date
 			Expect(program.Description).To(PointTo(Equal(fmt.Sprintf("Last Upload: 2024-01-18 | Last Viewed by You: %s", today))))


### PR DESCRIPTION
- Update patient count settings when clinic country changes
- When clinic country changes to US, apply default patient count settings
- When clinic country changes to OUS, remove patient count settings
- Preserve patient count and patient count settings when clinic updated
- Fix UTC time bug in Xealth integration tests
- https://tidepool.atlassian.net/browse/BACK-2973
- https://tidepool.atlassian.net/browse/BACK-2970