### PR TITLE
batch patient lists for clinic merges

### DIFF
--- a/clinics/merge/clinic.go
+++ b/clinics/merge/clinic.go
@@ -344,6 +344,12 @@ func (c *ClinicPlanExecutor) Execute(ctx context.Context, plan ClinicMergePlan) 
 			if err := ppe.Execute(ctx, p, plan.Source, plan.Target); err != nil {
 				return nil, err
 			}
+			if p.SourcePatient != nil {
+				sanitizePatient(p.SourcePatient)
+			}
+			if p.TargetPatient != nil {
+				sanitizePatient(p.TargetPatient)
+			}
 			if err := c.persistPlan(ctx, NewPersistentPlan(planId, planTypePatient, p)); err != nil {
 				return nil, err
 			}

--- a/clinics/merge/cluster_test.go
+++ b/clinics/merge/cluster_test.go
@@ -3,12 +3,13 @@ package merge_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/tidepool-org/clinic/clinics/merge"
 	mergeTest "github.com/tidepool-org/clinic/clinics/merge/test"
 )
 
 const (
-	expectedClusters = 50
+	expectedClusters                      = 50
 	inClusterLikelyDuplicateAccountsCount = 2
 	inClusterNameOnlyMatchAccountsCount   = 3
 	inClusterMRNOnlyMatchAccountsCount    = 4
@@ -39,7 +40,7 @@ var _ = Describe("Patient Cluster Reporter", func() {
 			Expect(clusters).To(HaveLen(expectedClusters))
 		})
 
-		It("have the expected number of duplicates withing the cluster", func() {
+		It("have the expected number of duplicates within the cluster", func() {
 			expectedClusterSize := 1 + inClusterLikelyDuplicateAccountsCount + inClusterMRNOnlyMatchAccountsCount + inClusterNameOnlyMatchAccountsCount
 			for _, cluster := range clusters {
 				Expect(cluster.Patients).To(HaveLen(expectedClusterSize))

--- a/clinics/merge/patients.go
+++ b/clinics/merge/patients.go
@@ -3,14 +3,16 @@ package merge
 import (
 	"context"
 	"fmt"
+	"time"
+
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/tidepool-org/clinic/clinics"
-	"github.com/tidepool-org/clinic/patients"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
-	"time"
+
+	"github.com/tidepool-org/clinic/clinics"
+	"github.com/tidepool-org/clinic/patients"
 )
 
 const (
@@ -169,7 +171,6 @@ func (p *PatientMergePlanner) Plan(ctx context.Context) (PatientPlans, error) {
 	mergeTargetPatients := map[string]struct{}{}
 	list := make([]PatientPlan, 0, len(p.sourcePatients)+len(p.targetPatients))
 	for _, patient := range p.sourcePatients {
-		sanitizePatient(&patient)
 		plan := PatientPlan{
 			SourceClinicId:        p.source.Id,
 			SourceClinicName:      *p.source.Name,
@@ -190,7 +191,6 @@ func (p *PatientMergePlanner) Plan(ctx context.Context) (PatientPlans, error) {
 				return nil, err
 			}
 
-			sanitizePatient(target)
 			if conflictCategory == PatientConflictCategoryDuplicateAccounts {
 				mergeTargetPatients[userId] = struct{}{}
 				plan.PatientAction = PatientActionMerge
@@ -233,7 +233,6 @@ func (p *PatientMergePlanner) Plan(ctx context.Context) (PatientPlans, error) {
 	}
 
 	for _, patient := range p.targetPatients {
-		sanitizePatient(&patient)
 		plan := PatientPlan{
 			SourceClinicId:   p.source.Id,
 			SourceClinicName: *p.source.Name,

--- a/clinics/merge/report_test.go
+++ b/clinics/merge/report_test.go
@@ -1,0 +1,124 @@
+package merge_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tealeg/xlsx/v3"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/tidepool-org/clinic/clinics"
+	"github.com/tidepool-org/clinic/clinics/merge"
+	"github.com/tidepool-org/clinic/patients"
+)
+
+var _ = Describe("merge reports", func() {
+	Context("where the source clinic's first patient has a summary", func() {
+		It("has a last upload date in the report", func() {
+			at := time.Now().Add(-time.Hour)
+			plan := newTestPlan(at)
+			report := merge.NewReport(plan)
+			xlsxFile, err := report.Generate()
+			Expect(err).To(Succeed())
+			Expect(xlsxFile).ToNot(BeNil())
+			Expect(xlsxHasLatestUpload(at, xlsxFile, sourcePatientsSheetIdx, firstPatientRowIdx)).To(BeTrue())
+		})
+	})
+})
+
+func xlsxHasLatestUpload(date time.Time, f *xlsx.File, sheetIdx, rowIdx int) bool {
+	m, err := f.ToSlice()
+	Expect(err).To(Succeed())
+	return m[sheetIdx][rowIdx][latestUploadColIdx] == date.Format(merge.LastUploadTimeFormat)
+}
+
+// sourcePatientsSheetIdx is the 0-based index of the sheet in the xlsx.
+const sourcePatientsSheetIdx = 1
+
+// firstPatientRowIdx is the 0-based index of the first patient data row in the xlsx.
+const firstPatientRowIdx = 2
+
+// latestUploadColIdx is the 0-based index of the Latest Upload column in the xlsx.
+const latestUploadColIdx = 6
+
+func newTestPlan(at time.Time) merge.ClinicMergePlan {
+	return merge.ClinicMergePlan{
+		Source:                          clinics.Clinic{},
+		Target:                          clinics.Clinic{},
+		MembershipRestrictionsMergePlan: merge.MembershipRestrictionsMergePlan{},
+		SourcePatientClusters:           merge.PatientClusters{},
+		TargetPatientClusters:           merge.PatientClusters{},
+		SettingsPlans:                   merge.SettingsPlans{},
+		TagsPlans:                       merge.TagPlans{},
+		ClinicianPlans:                  merge.ClinicianPlans{},
+		PatientPlans: merge.PatientPlans{
+			{
+				SourceClinicId:   &primitive.ObjectID{},
+				TargetClinicId:   &primitive.ObjectID{},
+				SourceClinicName: "",
+				TargetClinicName: "",
+				SourcePatient: &patients.Patient{
+					Id:                 &primitive.ObjectID{},
+					ClinicId:           &primitive.ObjectID{},
+					UserId:             new(string),
+					BirthDate:          new(string),
+					Email:              new(string),
+					FullName:           new(string),
+					Mrn:                new(string),
+					TargetDevices:      &[]string{},
+					Tags:               &[]primitive.ObjectID{},
+					DataSources:        &[]patients.DataSource{},
+					Permissions:        &patients.Permissions{},
+					IsMigrated:         false,
+					LegacyClinicianIds: []string{},
+					CreatedTime:        time.Time{},
+					UpdatedTime:        time.Time{},
+					InvitedBy:          new(string),
+					Summary: &patients.Summary{
+						CGM: &patients.PatientCGMStats{
+							Config: patients.PatientSummaryConfig{},
+							Dates: patients.PatientSummaryDates{
+								FirstData:         &time.Time{},
+								HasFirstData:      false,
+								HasLastData:       false,
+								HasLastUploadDate: false,
+								HasOutdatedSince:  false,
+								LastData:          &time.Time{},
+								LastUpdatedDate:   &time.Time{},
+								LastUpdatedReason: &[]string{},
+								// !!!
+								// !!! Here we set the date via "at"
+								// !!!
+								LastUploadDate:     &at,
+								OutdatedReason:     &[]string{},
+								OutdatedSince:      &time.Time{},
+								OutdatedSinceLimit: &time.Time{},
+							},
+							OffsetPeriods: patients.PatientCGMPeriods{},
+							Periods:       patients.PatientCGMPeriods{},
+							TotalHours:    0,
+						},
+						BGM: &patients.PatientBGMStats{},
+					},
+					Reviews:                        []patients.Review{},
+					LastUploadReminderTime:         time.Time{},
+					ProviderConnectionRequests:     patients.ProviderConnectionRequests{},
+					RequireUniqueMrn:               false,
+					EHRSubscriptions:               patients.EHRSubscriptions{},
+					LastRequestedDexcomConnectTime: at,
+				},
+				TargetPatient:              &patients.Patient{},
+				Conflicts:                  map[string][]merge.Conflict{},
+				PatientAction:              "",
+				SourceTagNames:             []string{},
+				TargetTagNames:             []string{},
+				PostMigrationTagNames:      []string{},
+				PostMigrationMRNUniqueness: false,
+				CanExecuteAction:           false,
+				Error:                      &merge.ReportError{},
+			},
+		},
+		CreatedTime: time.Time{},
+	}
+}

--- a/patients/patients.go
+++ b/patients/patients.go
@@ -183,7 +183,8 @@ type Filter struct {
 	CGMTime SummaryDateFilters
 	BGMTime SummaryDateFilters
 
-	ExcludeDemo bool
+	ExcludeDemo    bool
+	ExcludeSummary bool
 }
 
 type Permission = map[string]interface{}

--- a/patients/patients.go
+++ b/patients/patients.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
 	"github.com/tidepool-org/clinic/errors"
 	"github.com/tidepool-org/clinic/store"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 const (
@@ -94,7 +95,7 @@ type Patient struct {
 	EHRSubscriptions           EHRSubscriptions           `bson:"ehrSubscriptions,omitempty"`
 
 	// DEPRECATED: Remove when Tidepool Web starts using provider connection requests
-	LastRequestedDexcomConnectTime time.Time             `bson:"lastRequestedDexcomConnectTime,omitempty"`
+	LastRequestedDexcomConnectTime time.Time `bson:"lastRequestedDexcomConnectTime,omitempty"`
 }
 
 func (p Patient) IsCustodial() bool {
@@ -183,8 +184,12 @@ type Filter struct {
 	CGMTime SummaryDateFilters
 	BGMTime SummaryDateFilters
 
-	ExcludeDemo    bool
-	ExcludeSummary bool
+	ExcludeDemo bool
+	// ExcludeSummaryExceptFieldsInMergeReports along with its helper function
+	// excludeSummaryExceptFieldsInMergeReports are used to reduce a patient's [Summary] to
+	// the minimum content needed to generate clinic merge reports and perform clinic
+	// merges.
+	ExcludeSummaryExceptFieldsInMergeReports bool
 }
 
 type Permission = map[string]interface{}
@@ -208,9 +213,9 @@ type ListResult struct {
 }
 
 type PatientUpdate struct {
-	ClinicId  string
-	UserId    string
-	Patient   Patient
+	ClinicId string
+	UserId   string
+	Patient  Patient
 }
 
 type UploadReminderUpdate struct {

--- a/patients/repo.go
+++ b/patients/repo.go
@@ -203,8 +203,11 @@ func (r *repository) List(ctx context.Context, filter *Filter, pagination store.
 	// and the patients from a single query
 	pipeline := []bson.M{
 		{"$match": r.generateListFilterQuery(filter)},
-		{"$sort": generateListSortStage(sorts)},
 	}
+	if filter.ExcludeSummary {
+		pipeline = append(pipeline, bson.M{"$unset": "summary"})
+	}
+	pipeline = append(pipeline, bson.M{"$sort": generateListSortStage(sorts)})
 	pipeline = append(pipeline, generatePaginationFacetStages(pagination)...)
 
 	hasFullNameSort := false


### PR DESCRIPTION
Our first real attempt to generate a clinic merge report failed
because the patient list exceeded MongoDB's 16 MB Document limit.

Some quick math indicated that more than 1,600 patients could trigger
that limit, and so this code modifies the merge process to list
patients in batches of 1,024 at a time.

The test for this is very slow (due to patient creation), so I welcome
suggestions for improving that (with the understanding that they might
have to come later, this is a high priority backend hero ticket at the
moment.)

SIR-603
BACK-3684 (created after the fact)