### PR TITLE
[BACK-4315] Allow backend services to send provider connection requests

### DIFF
--- a/api/patients.go
+++ b/api/patients.go
@@ -503,8 +503,11 @@ func (h *Handler) ConnectProvider(ec echo.Context, clinicId ClinicId, patientId 
 	ctx := ec.Request().Context()
 
 	authData := auth.GetAuthData(ctx)
-	if err := authData.AssertAuthenticatedUser(); err != nil {
-		return err
+	if authData == nil || authData.SubjectId == "" {
+		return &echo.HTTPError{
+			Code:    http.StatusBadRequest,
+			Message: "expected authenticated user id",
+		}
 	}
 
 	provider, err := NewDataProvider(providerId)

--- a/auth/authorizer_test.go
+++ b/auth/authorizer_test.go
@@ -1212,6 +1212,19 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("allows backend services to send a provider connection request", func() {
+		input := map[string]interface{}{
+			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "1234567890", "connect", "dexcom"},
+			"method": "POST",
+			"auth": map[string]interface{}{
+				"subjectId":    "clinic-worker",
+				"serverAccess": true,
+			},
+		}
+		err := authorizer.EvaluatePolicy(context.Background(), input)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("it allows orca to merge clinics", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "merge"},

--- a/auth/authorizer_test.go
+++ b/auth/authorizer_test.go
@@ -1225,6 +1225,58 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("prevents unauthenticated requests from sending a provider connection request", func() {
+		input := map[string]interface{}{
+			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "1234567890", "connect", "dexcom"},
+			"method": "POST",
+		}
+		err := authorizer.EvaluatePolicy(context.Background(), input)
+		Expect(err).To(Equal(auth.ErrUnauthorized))
+	})
+
+	It("allows a clinician with read access to send a provider connection request", func() {
+		input := map[string]interface{}{
+			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "1234567890", "connect", "dexcom"},
+			"method": "POST",
+			"auth": map[string]interface{}{
+				"subjectId":    "clinician-user-id",
+				"serverAccess": false,
+			},
+			"clinician": clinicMember,
+		}
+		err := authorizer.EvaluatePolicy(context.Background(), input)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("prevents a clinician without read access from sending a provider connection request", func() {
+		input := map[string]interface{}{
+			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "1234567890", "connect", "dexcom"},
+			"method": "POST",
+			"auth": map[string]interface{}{
+				"subjectId":    "clinician-user-id",
+				"serverAccess": false,
+			},
+			"clinician": map[string]interface{}{
+				"roles": []string{},
+			},
+		}
+		err := authorizer.EvaluatePolicy(context.Background(), input)
+		Expect(err).To(Equal(auth.ErrUnauthorized))
+	})
+
+	It("prevents a patient from sending a provider connection request for themselves", func() {
+		input := map[string]interface{}{
+			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "1234567890", "connect", "dexcom"},
+			"method": "POST",
+			"auth": map[string]interface{}{
+				"subjectId":    "1234567890",
+				"serverAccess": false,
+			},
+		}
+		err := authorizer.EvaluatePolicy(context.Background(), input)
+		Expect(err).To(Equal(auth.ErrUnauthorized))
+	})
+
 	It("it allows orca to merge clinics", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "merge"},

--- a/auth/policy.rego
+++ b/auth/policy.rego
@@ -402,6 +402,14 @@ allow {
   clinician_has_read_access
 }
 
+# Allow backend services to send a provider connection request
+# POST /v1/clinics/:clinicId/patients/:patientId/connect/:provider
+allow {
+  input.method == "POST"
+  input.path = ["v1", "clinics", _, "patients", _, "connect", _]
+  is_backend_service
+}
+
 # Allow currently authenticated clinician to fetch patient by id
 # GET /v1/clinics/:clinicId/patients/:patientId
 allow {


### PR DESCRIPTION
[BACK-4315]
Allow orca to send provider connection requests to patients.

[BACK-4315]: https://tidepool.atlassian.net/browse/BACK-4315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ