### PR TITLE
[BACK-4387] Update TIDE category boundaries to be inclusive rounded values.

### DIFF
--- a/patients/repository/repository.go
+++ b/patients/repository/repository.go
@@ -1517,17 +1517,37 @@ type tideCategory struct {
 	//          0 - no sorting
 	//        > 0 - sort in ascending order
 	SummaryFieldSortOrder int
-	// SummaryFieldFilters optionally filter a category while querying.
-	SummaryFieldFilters []summaryFieldFilter
+	// [Predicates] returns an array of mongodb find predicates suitable for input to
+	// the `$and` operator - see [queryPredicates].
+	Predicates queryPredicates
 }
 
-// summaryFieldFilter allows defines a query on a summary field
-type summaryFieldFilter struct {
-	SummaryField string
+// queryPredicates is a function that, given the path prefix of the current
+// period, e.g., "summary.cgmStats.periods.14d", returns an array of mongodb
+// query predicates suitable as input into the `$and` operator for a `find`
+// operation.
+type queryPredicates func(parentFieldPath string) bson.A
 
-	// [QueryPredicate] is the mongodb expression to be used to compare [SummaryField] against to see if it matches a certain category.
-	QueryPredicate bson.M
+// roundFieldExpr is a convenience function that returns a mongoDB expression
+// that rounds the given field.
+func roundFieldExpr(field string) bson.M {
+	fieldPathExpr := field
+	if !strings.HasPrefix(fieldPathExpr, "$") {
+		fieldPathExpr = "$" + fieldPathExpr
+	}
+	return bson.M{
+		"$round": bson.A{
+			bson.M{
+				"$multiply": bson.A{
+					fieldPathExpr,
+					100,
+				},
+			},
+		},
+	}
 }
+
+const halfAPercent = 0.005
 
 // availableCategories are the categories available for a TIDE report.
 var availableCategories = [...]tideCategory{
@@ -1535,124 +1555,222 @@ var availableCategories = [...]tideCategory{
 		CategoryName:          "timeInVeryLowPercent",
 		SummaryField:          "timeInVeryLowPercent",
 		SummaryFieldSortOrder: -1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInVeryLowPercent",
-				QueryPredicate: bson.M{"$gte": 0.01},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInVeryLowPercent"
+			return bson.A{
+				// These redundant looking {"$gt": # +/- halfAPercent} predicates are
+				// used to allow an index to be (possibly) be used. This is because
+				// MongoDB does not support indexes on calculated expressions, but only
+				// fields. By including them, the index may be used for filtering or
+				// sorting, after which the rounded predicate would be rechecked. This
+				// however does require knowledge of both the boundary conditions and
+				// banker's rounding rules. The actual rounded predicate must also be
+				// present for the correct categorization calculation.
+				// The other alternative was storing the rounded results w/ the
+				// summary. I feel this requires considerably more work as it touches
+				// summary service & clinic worker & would require populating existing
+				// summary fields.
+				bson.M{field: bson.M{"$gt": 0.01 - halfAPercent}}, // > because round(0.005) = round(0.5%) = 0% so only values > 0.5% round to 1
+				bson.M{"$expr": bson.M{
+					"$gte": bson.A{
+						roundFieldExpr(field),
+						1,
+					},
+				}},
+			}
+		},
 	},
+
 	{
 		CategoryName:          "timeInAnyLowPercent",
 		SummaryField:          "timeInAnyLowPercent",
 		SummaryFieldSortOrder: -1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInAnyLowPercent",
-				QueryPredicate: bson.M{"$gte": 0.04},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInAnyLowPercent"
+			return bson.A{
+				bson.M{field: bson.M{"$gte": 0.04 - halfAPercent}}, // >= because round(0.035) = round(3.5%) = 4% so values greater than or equal to 3.5% round to 4%
+				bson.M{"$expr": bson.M{
+					"$gte": bson.A{
+						roundFieldExpr(field),
+						4,
+					},
+				}},
+			}
+		},
 	},
 	{
 		CategoryName:          "dropInTimeInTargetPercent",
 		SummaryField:          "timeInTargetPercentDelta",
 		SummaryFieldSortOrder: 1, // ascending sort so that largest negative value is first
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInTargetPercentDelta",
-				QueryPredicate: bson.M{"$lte": -0.15},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInTargetPercentDelta"
+			return bson.A{
+				bson.M{field: bson.M{"$lt": -0.15 + halfAPercent}}, // < because round(-0.145) = round(-14.5%) = 14% so values less than -14.5% rounds to -15%.
+				bson.M{"$expr": bson.M{
+					"$lte": bson.A{
+						roundFieldExpr(field),
+						-15,
+					},
+				}},
+			}
+		},
 	},
 	{
 		CategoryName:          "timeCGMUsePercent",
 		SummaryField:          "timeCGMUsePercent",
 		SummaryFieldSortOrder: 1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeCGMUsePercent",
-				QueryPredicate: bson.M{"$lte": 0.7},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeCGMUsePercent"
+			return bson.A{
+				bson.M{field: bson.M{"$lt": 0.70 - halfAPercent}}, // < because round(0.695) = round(69.5%) = 70% so values less than 69.5% round to < 70%.
+				bson.M{"$expr": bson.M{
+					"$lte": bson.A{
+						roundFieldExpr(field),
+						70,
+					},
+				}},
+			}
+		},
 	},
 	{
 		CategoryName:          "timeInTargetPercent",
 		SummaryField:          "timeInTargetPercent",
 		SummaryFieldSortOrder: 1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInTargetPercent",
-				QueryPredicate: bson.M{"$lte": 0.7},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInTargetPercent"
+			return bson.A{
+				bson.M{field: bson.M{"$lte": 0.70 + halfAPercent}}, // <= because round(0.705) = round(70.5%) = 70% so values less than or equal to 70.5% round to <= 70%.
+				bson.M{"$expr": bson.M{
+					"$lte": bson.A{
+						roundFieldExpr(field),
+						70,
+					},
+				}},
+			}
+		},
 	},
 	{
 		CategoryName:          "meetingTargets",
 		SummaryField:          "timeInTargetPercent",
 		SummaryFieldSortOrder: -1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInTargetPercent",
-				QueryPredicate: bson.M{"$gt": 0.7},
-			},
-			{
-				SummaryField:   "timeCGMUsePercent",
-				QueryPredicate: bson.M{"$gte": 0.7},
-			},
-			// These "$not" expressions are used because the fields may not exist in
-			// the patient summary. They are usually used when comparing for flagged
-			// conidtions as those may not exist dpending on the patient if they
-			// never spent time in that state.
-			// So that query will pass if either:
-			//   * The summary field exists and it matches the predicate.
-			//   OR
-			//   * The summary field does not exist
-			{
-				SummaryField:   "timeInAnyLowPercent",
-				QueryPredicate: bson.M{"$not": bson.M{"$gte": .04}},
-			},
-			{
-				SummaryField:   "timeInVeryLowPercent",
-				QueryPredicate: bson.M{"$not": bson.M{"$gte": .01}},
-			},
-			{
-				SummaryField:   "timeInAnyHighPercent",
-				QueryPredicate: bson.M{"$not": bson.M{"$gte": .25}},
-			},
-			{
-				SummaryField:   "timeInVeryHighPercent",
-				QueryPredicate: bson.M{"$not": bson.M{"$gte": .05}},
-			},
-			{
-				SummaryField:   "timeInExtremeHighPercent",
-				QueryPredicate: bson.M{"$not": bson.M{"$gte": .01}},
-			},
+		Predicates: func(parentFieldPath string) bson.A {
+			timeInTargetPercent := parentFieldPath + "." + "timeInTargetPercent"
+			timeCGMUsePercent := parentFieldPath + "." + "timeCGMUsePercent"
+			timeInLowPercent := parentFieldPath + "." + "timeInLowPercent"
+			timeInVeryLowPercent := parentFieldPath + "." + "timeInVeryLowPercent"
+			timeInAnyHighPercent := parentFieldPath + "." + "timeInAnyHighPercent"
+			timeInVeryHighPercent := parentFieldPath + "." + "timeInVeryHighPercent"
+			timeInExtremeHighPercent := parentFieldPath + "." + "timeInExtremeHighPercent"
+			return bson.A{
+				bson.M{timeInTargetPercent: bson.M{"$gt": 0.70 + halfAPercent}},
+				bson.M{"$expr": bson.M{
+					"$gt": bson.A{
+						roundFieldExpr(timeInTargetPercent),
+						70,
+					},
+				}},
+				bson.M{timeCGMUsePercent: bson.M{"$gte": 0.70 - halfAPercent}},
+				bson.M{"$expr": bson.M{
+					"$gte": bson.A{
+						roundFieldExpr(timeCGMUsePercent),
+						70,
+					},
+				}},
+				// These "$not" expressions are used because the fields may not exist in
+				// the patient summary if no data was within a category's thresholds.
+				//
+				// So that query will pass if either:
+				//   * The summary field exists and it matches the predicate.
+				//   OR
+				//   * The summary field does not exist
+				bson.M{"$expr": bson.M{
+					"$not": bson.M{
+						"$gte": bson.A{
+							roundFieldExpr(timeInLowPercent),
+							4,
+						},
+					}}},
+				bson.M{"$expr": bson.M{
+					"$not": bson.M{
+						"$gte": bson.A{
+							roundFieldExpr(timeInVeryLowPercent),
+							1,
+						},
+					}}},
+				bson.M{"$expr": bson.M{
+					"$not": bson.M{
+						"$gte": bson.A{
+							roundFieldExpr(timeInAnyHighPercent),
+							25,
+						},
+					}}},
+				bson.M{"$expr": bson.M{
+					"$not": bson.M{
+						"$gte": bson.A{
+							roundFieldExpr(timeInVeryHighPercent),
+							5,
+						},
+					}}},
+				bson.M{"$expr": bson.M{
+					"$not": bson.M{
+						"$gte": bson.A{
+							roundFieldExpr(timeInExtremeHighPercent),
+							1,
+						},
+					}}},
+			}
 		},
 	},
 	{
 		CategoryName:          "timeInExtremeHighPercent",
 		SummaryField:          "timeInExtremeHighPercent",
 		SummaryFieldSortOrder: -1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInExtremeHighPercent",
-				QueryPredicate: bson.M{"$gte": 0.01},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInExtremeHighPercent"
+			return bson.A{
+				bson.M{field: bson.M{"$gt": 0.01 - halfAPercent}},
+				bson.M{"$expr": bson.M{
+					"$gte": bson.A{
+						roundFieldExpr(field),
+						1,
+					},
+				}},
+			}
+		},
 	},
 	{
 		CategoryName:          "timeInVeryHighPercent",
 		SummaryField:          "timeInVeryHighPercent",
 		SummaryFieldSortOrder: -1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInVeryHighPercent",
-				QueryPredicate: bson.M{"$gte": 0.05},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInVeryHighPercent"
+			return bson.A{
+				bson.M{field: bson.M{"$gt": 0.05 - halfAPercent}},
+				bson.M{"$expr": bson.M{
+					"$gte": bson.A{
+						roundFieldExpr(field),
+						5,
+					},
+				}},
+			}
+		},
 	},
 	{
 		CategoryName:          "timeInAnyHighPercent",
 		SummaryField:          "timeInAnyHighPercent",
 		SummaryFieldSortOrder: -1,
-		SummaryFieldFilters: []summaryFieldFilter{
-			{
-				SummaryField:   "timeInAnyHighPercent",
-				QueryPredicate: bson.M{"$gte": 0.25},
-			}},
+		Predicates: func(parentFieldPath string) bson.A {
+			field := parentFieldPath + "." + "timeInAnyHighPercent"
+			return bson.A{
+				bson.M{field: bson.M{"$gt": 0.25 - halfAPercent}},
+				bson.M{"$expr": bson.M{
+					"$gte": bson.A{
+						roundFieldExpr(field),
+						25,
+					},
+				}},
+			}
+		},
 	},
 }
 
@@ -1744,8 +1862,14 @@ func (r *repository) TideReport(ctx context.Context, clinicId string, params pat
 		opts := options.Find()
 		opts.SetLimit(int64(remaining))
 
-		for _, filter := range category.SummaryFieldFilters {
-			selector["summary.cgmStats.periods."+params.Period+"."+filter.SummaryField] = filter.QueryPredicate
+		var exprs bson.A
+		parentFieldPath := "summary.cgmStats.periods." + params.Period
+		if category.Predicates != nil {
+			preds := category.Predicates(parentFieldPath)
+			exprs = append(exprs, preds...)
+		}
+		if len(exprs) > 0 {
+			selector["$and"] = exprs
 		}
 
 		sortKey := "summary.cgmStats.periods." + params.Period + "." + category.SummaryField

--- a/patients/repository/repository.go
+++ b/patients/repository/repository.go
@@ -1524,10 +1524,9 @@ type tideCategory struct {
 // summaryFieldFilter allows defines a query on a summary field
 type summaryFieldFilter struct {
 	SummaryField string
-	// SummaryFieldComparator is the mongodb comparison operator, e.g., `$gt`, `$not`, etc used with one of the operands being [SummaryField] and the other operand [ComparatorOperandExpression].
-	SummaryFieldComparator string
-	// ComparatorOperandExpression is an expression to compare [SummaryField] against. Because it may take different forms it is of type any. This may be a simple value like an string, int32, long or an object.
-	ComparatorOperandExpression any
+
+	// [QueryPredicate] is the mongodb expression to be used to compare [SummaryField] against to see if it matches a certain category.
+	QueryPredicate bson.M
 }
 
 // availableCategories are the categories available for a TIDE report.
@@ -1538,9 +1537,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: -1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInVeryLowPercent",
-				SummaryFieldComparator:      "$gt",
-				ComparatorOperandExpression: 0.01,
+				SummaryField:   "timeInVeryLowPercent",
+				QueryPredicate: bson.M{"$gte": 0.01},
 			}},
 	},
 	{
@@ -1549,9 +1547,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: -1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInAnyLowPercent",
-				SummaryFieldComparator:      "$gt",
-				ComparatorOperandExpression: 0.04,
+				SummaryField:   "timeInAnyLowPercent",
+				QueryPredicate: bson.M{"$gte": 0.04},
 			}},
 	},
 	{
@@ -1560,9 +1557,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: 1, // ascending sort so that largest negative value is first
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInTargetPercentDelta",
-				SummaryFieldComparator:      "$lt",
-				ComparatorOperandExpression: -0.15,
+				SummaryField:   "timeInTargetPercentDelta",
+				QueryPredicate: bson.M{"$lte": -0.15},
 			}},
 	},
 	{
@@ -1571,9 +1567,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: 1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeCGMUsePercent",
-				SummaryFieldComparator:      "$lt",
-				ComparatorOperandExpression: 0.7,
+				SummaryField:   "timeCGMUsePercent",
+				QueryPredicate: bson.M{"$lte": 0.7},
 			}},
 	},
 	{
@@ -1582,9 +1577,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: 1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInTargetPercent",
-				SummaryFieldComparator:      "$lt",
-				ComparatorOperandExpression: 0.7,
+				SummaryField:   "timeInTargetPercent",
+				QueryPredicate: bson.M{"$lte": 0.7},
 			}},
 	},
 	{
@@ -1593,40 +1587,40 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: -1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInTargetPercent",
-				SummaryFieldComparator:      "$gte",
-				ComparatorOperandExpression: 0.7,
+				SummaryField:   "timeInTargetPercent",
+				QueryPredicate: bson.M{"$gt": 0.7},
 			},
 			{
-				SummaryField:                "timeCGMUsePercent",
-				SummaryFieldComparator:      "$gte",
-				ComparatorOperandExpression: 0.7,
+				SummaryField:   "timeCGMUsePercent",
+				QueryPredicate: bson.M{"$gte": 0.7},
 			},
-			// These "$not" expressions are because the fields may not exist in the patient summary
+			// These "$not" expressions are used because the fields may not exist in
+			// the patient summary. They are usually used when comparing for flagged
+			// conidtions as those may not exist dpending on the patient if they
+			// never spent time in that state.
+			// So that query will pass if either:
+			//   * The summary field exists and it matches the predicate.
+			//   OR
+			//   * The summary field does not exist
 			{
-				SummaryField:                "timeInAnyLowPercent",
-				SummaryFieldComparator:      "$not",
-				ComparatorOperandExpression: bson.M{"$gt": .04},
-			},
-			{
-				SummaryField:                "timeInVeryLowPercent",
-				SummaryFieldComparator:      "$not",
-				ComparatorOperandExpression: bson.M{"$gt": .01},
-			},
-			{
-				SummaryField:                "timeInAnyHighPercent",
-				SummaryFieldComparator:      "$not",
-				ComparatorOperandExpression: bson.M{"$gt": .25},
+				SummaryField:   "timeInAnyLowPercent",
+				QueryPredicate: bson.M{"$not": bson.M{"$gte": .04}},
 			},
 			{
-				SummaryField:                "timeInVeryHighPercent",
-				SummaryFieldComparator:      "$not",
-				ComparatorOperandExpression: bson.M{"$gt": .05},
+				SummaryField:   "timeInVeryLowPercent",
+				QueryPredicate: bson.M{"$not": bson.M{"$gte": .01}},
 			},
 			{
-				SummaryField:                "timeInExtremeHighPercent",
-				SummaryFieldComparator:      "$not",
-				ComparatorOperandExpression: bson.M{"$gte": .01},
+				SummaryField:   "timeInAnyHighPercent",
+				QueryPredicate: bson.M{"$not": bson.M{"$gte": .25}},
+			},
+			{
+				SummaryField:   "timeInVeryHighPercent",
+				QueryPredicate: bson.M{"$not": bson.M{"$gte": .05}},
+			},
+			{
+				SummaryField:   "timeInExtremeHighPercent",
+				QueryPredicate: bson.M{"$not": bson.M{"$gte": .01}},
 			},
 		},
 	},
@@ -1636,9 +1630,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: -1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInExtremeHighPercent",
-				SummaryFieldComparator:      "$gte",
-				ComparatorOperandExpression: 0.01,
+				SummaryField:   "timeInExtremeHighPercent",
+				QueryPredicate: bson.M{"$gte": 0.01},
 			}},
 	},
 	{
@@ -1647,9 +1640,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: -1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInVeryHighPercent",
-				SummaryFieldComparator:      "$gt",
-				ComparatorOperandExpression: 0.05,
+				SummaryField:   "timeInVeryHighPercent",
+				QueryPredicate: bson.M{"$gte": 0.05},
 			}},
 	},
 	{
@@ -1658,9 +1650,8 @@ var availableCategories = [...]tideCategory{
 		SummaryFieldSortOrder: -1,
 		SummaryFieldFilters: []summaryFieldFilter{
 			{
-				SummaryField:                "timeInAnyHighPercent",
-				SummaryFieldComparator:      "$gt",
-				ComparatorOperandExpression: 0.25,
+				SummaryField:   "timeInAnyHighPercent",
+				QueryPredicate: bson.M{"$gte": 0.25},
 			}},
 	},
 }
@@ -1754,7 +1745,7 @@ func (r *repository) TideReport(ctx context.Context, clinicId string, params pat
 		opts.SetLimit(int64(remaining))
 
 		for _, filter := range category.SummaryFieldFilters {
-			selector["summary.cgmStats.periods."+params.Period+"."+filter.SummaryField] = bson.M{filter.SummaryFieldComparator: filter.ComparatorOperandExpression}
+			selector["summary.cgmStats.periods."+params.Period+"."+filter.SummaryField] = filter.QueryPredicate
 		}
 
 		sortKey := "summary.cgmStats.periods." + params.Period + "." + category.SummaryField

--- a/patients/repository/repository.go
+++ b/patients/repository/repository.go
@@ -1622,7 +1622,10 @@ var availableCategories = [...]tideCategory{
 		Predicates: func(parentFieldPath string) bson.A {
 			field := parentFieldPath + "." + "timeCGMUsePercent"
 			return bson.A{
-				bson.M{field: bson.M{"$lt": 0.70 - halfAPercent}}, // < because round(0.695) = round(69.5%) = 70% so values less than 69.5% round to < 70%.
+				// patients who are flagged in the "timeCGMUsePercent" have a cgm wear
+				// time < 70%. This is one of the few fields that uses an exclusive
+				// bounds instead of inclusive.
+				bson.M{field: bson.M{"$lt": 0.70 - halfAPercent}}, // <= because round(0.695) = round(69.5%) = 70% so values less than 69.5% round to < 70%.
 				bson.M{"$expr": bson.M{
 					"$lte": bson.A{
 						roundFieldExpr(field),

--- a/patients/repository/repository_test.go
+++ b/patients/repository/repository_test.go
@@ -38,6 +38,11 @@ import (
 
 var DemoPatientId = "demo"
 
+const (
+	maxRecords14d = 4032  // Assuming 14d period and data read every 5 minutes
+	maxMinutes14d = 20160 // 60 * 14 * 24
+)
+
 var _ = Describe("Patients Repository", func() {
 	var cfg *config.Config
 	var repo patients.Repository
@@ -2483,17 +2488,17 @@ var _ = Describe("TideReport", func() {
 					Expect(report.Metadata.CandidatePatients).To(Equal(13))
 					Expect(report.Metadata.SelectedPatients).To(Equal(13))
 
-					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
+					Expect(report.Results["timeInVeryLowPercent"]).To(matchTIDEPatients(timeInVeryLowResults))
 
-					Expect(report.Results["timeInAnyLowPercent"]).To(tideResultsPatientMatcher(timeInAnyLowPercentResults))
+					Expect(report.Results["timeInAnyLowPercent"]).To(matchTIDEPatients(timeInAnyLowPercentResults))
 
-					Expect(report.Results["timeCGMUsePercent"]).To(tideResultsPatientMatcher(timeCGMUsePercentResults))
+					Expect(report.Results["timeCGMUsePercent"]).To(matchTIDEPatients(timeCGMUsePercentResults))
 
-					Expect(report.Results["noData"]).To(tideResultsPatientMatcher(noDataPatientResults))
+					Expect(report.Results["noData"]).To(matchTIDEPatients(noDataPatientResults))
 
-					Expect(report.Results["meetingTargets"]).To(tideResultsPatientMatcher(meetingTargetsResults))
-					Expect(report.Results["timeInVeryHighPercent"]).To(tideResultsPatientMatcher(timeInVeryHighResults))
-					Expect(report.Results["timeInAnyHighPercent"]).To(tideResultsPatientMatcher(timeInAnyHighResults))
+					Expect(report.Results["meetingTargets"]).To(matchTIDEPatients(meetingTargetsResults))
+					Expect(report.Results["timeInVeryHighPercent"]).To(matchTIDEPatients(timeInVeryHighResults))
+					Expect(report.Results["timeInAnyHighPercent"]).To(matchTIDEPatients(timeInAnyHighResults))
 				})
 
 				It("matches default categories if Tide Report params use explicitly empty categories", func(ctx SpecContext) {
@@ -2512,17 +2517,17 @@ var _ = Describe("TideReport", func() {
 					Expect(report.Metadata.CandidatePatients).To(Equal(13))
 					Expect(report.Metadata.SelectedPatients).To(Equal(13))
 
-					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
+					Expect(report.Results["timeInVeryLowPercent"]).To(matchTIDEPatients(timeInVeryLowResults))
 
-					Expect(report.Results["timeInAnyLowPercent"]).To(tideResultsPatientMatcher(timeInAnyLowPercentResults))
+					Expect(report.Results["timeInAnyLowPercent"]).To(matchTIDEPatients(timeInAnyLowPercentResults))
 
-					Expect(report.Results["timeCGMUsePercent"]).To(tideResultsPatientMatcher(timeCGMUsePercentResults))
+					Expect(report.Results["timeCGMUsePercent"]).To(matchTIDEPatients(timeCGMUsePercentResults))
 
-					Expect(report.Results["noData"]).To(tideResultsPatientMatcher(noDataPatientResults))
+					Expect(report.Results["noData"]).To(matchTIDEPatients(noDataPatientResults))
 
-					Expect(report.Results["meetingTargets"]).To(tideResultsPatientMatcher(meetingTargetsResults))
-					Expect(report.Results["timeInVeryHighPercent"]).To(tideResultsPatientMatcher(timeInVeryHighResults))
-					Expect(report.Results["timeInAnyHighPercent"]).To(tideResultsPatientMatcher(timeInAnyHighResults))
+					Expect(report.Results["meetingTargets"]).To(matchTIDEPatients(meetingTargetsResults))
+					Expect(report.Results["timeInVeryHighPercent"]).To(matchTIDEPatients(timeInVeryHighResults))
+					Expect(report.Results["timeInAnyHighPercent"]).To(matchTIDEPatients(timeInAnyHighResults))
 				})
 
 				It(`excludes the "noData" category if params excludeNoDataPatient is explicitly set`, func(ctx SpecContext) {
@@ -2541,15 +2546,15 @@ var _ = Describe("TideReport", func() {
 					Expect(report.Metadata.CandidatePatients).To(Equal(11))
 					Expect(report.Metadata.SelectedPatients).To(Equal(11))
 
-					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
+					Expect(report.Results["timeInVeryLowPercent"]).To(matchTIDEPatients(timeInVeryLowResults))
 
-					Expect(report.Results["timeInAnyLowPercent"]).To(tideResultsPatientMatcher(timeInAnyLowPercentResults))
+					Expect(report.Results["timeInAnyLowPercent"]).To(matchTIDEPatients(timeInAnyLowPercentResults))
 
-					Expect(report.Results["timeCGMUsePercent"]).To(tideResultsPatientMatcher(timeCGMUsePercentResults))
+					Expect(report.Results["timeCGMUsePercent"]).To(matchTIDEPatients(timeCGMUsePercentResults))
 
-					Expect(report.Results["meetingTargets"]).To(tideResultsPatientMatcher(meetingTargetsResults))
-					Expect(report.Results["timeInVeryHighPercent"]).To(tideResultsPatientMatcher(timeInVeryHighResults))
-					Expect(report.Results["timeInAnyHighPercent"]).To(tideResultsPatientMatcher(timeInAnyHighResults))
+					Expect(report.Results["meetingTargets"]).To(matchTIDEPatients(meetingTargetsResults))
+					Expect(report.Results["timeInVeryHighPercent"]).To(matchTIDEPatients(timeInVeryHighResults))
+					Expect(report.Results["timeInAnyHighPercent"]).To(matchTIDEPatients(timeInAnyHighResults))
 
 					Expect(report.Results["noData"]).To(BeEmpty())
 				})
@@ -2626,9 +2631,9 @@ var _ = Describe("TideReport", func() {
 							LastData:                 mustTime("2025-07-30T09:09:39.959Z"),
 						},
 					}
-					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
+					Expect(report.Results["timeInVeryLowPercent"]).To(matchTIDEPatients(timeInVeryLowResults))
 
-					Expect(report.Results["timeCGMUsePercent"]).To(tideResultsPatientMatcher(timeCGMUsePercentResults))
+					Expect(report.Results["timeCGMUsePercent"]).To(matchTIDEPatients(timeCGMUsePercentResults))
 				})
 
 				It(`meetingTargets correctly identifies patients meeting targets if no other categories are given in parameters`, func(ctx SpecContext) {
@@ -2710,7 +2715,7 @@ var _ = Describe("TideReport", func() {
 							LastData:                 mustTime("2025-07-07T16:28:39.66Z"),
 						},
 					}
-					Expect(report.Results["meetingTargets"]).To(tideResultsPatientMatcher(meetingTargetsResults))
+					Expect(report.Results["meetingTargets"]).To(matchTIDEPatients(meetingTargetsResults))
 				})
 
 				It(`meetingTargets and noData patients works`, func(ctx SpecContext) {
@@ -2792,8 +2797,8 @@ var _ = Describe("TideReport", func() {
 							LastData:                 mustTime("2025-07-07T16:28:39.66Z"),
 						},
 					}
-					Expect(report.Results["meetingTargets"]).To(tideResultsPatientMatcher(meetingTargetsResults))
-					Expect(report.Results["noData"]).To(tideResultsPatientMatcher(noDataPatientResults))
+					Expect(report.Results["meetingTargets"]).To(matchTIDEPatients(meetingTargetsResults))
+					Expect(report.Results["noData"]).To(matchTIDEPatients(noDataPatientResults))
 				})
 
 				It(`meetingTargets and another chosen category, "timeInVeryLowPercent" works`, func(ctx SpecContext) {
@@ -2875,8 +2880,8 @@ var _ = Describe("TideReport", func() {
 							LastData:                 mustTime("2025-07-07T16:28:39.66Z"),
 						},
 					}
-					Expect(report.Results["meetingTargets"]).To(tideResultsPatientMatcher(meetingTargetsResults))
-					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
+					Expect(report.Results["meetingTargets"]).To(matchTIDEPatients(meetingTargetsResults))
+					Expect(report.Results["timeInVeryLowPercent"]).To(matchTIDEPatients(timeInVeryLowResults))
 				})
 
 				It(`patient will be placed in "closest" category supplied in parameters when they "qualify" for a higher category. People in timeInVeryHighPercent will be placed in "lower" category timeInAnyHighPercent only if timeInAnyHighPercent category is selected before timeInVeryHighPercent or timeInVeryHighPercent is excluded in the category parameters`, func(ctx SpecContext) {
@@ -2897,8 +2902,640 @@ var _ = Describe("TideReport", func() {
 					Expect(report.Metadata.SelectedPatients).To(Equal(3))
 
 					timeInAnyHighAndUp := append(slices.Clone(timeInAnyHighResults), timeInVeryHighResults...)
-					Expect(report.Results["timeInAnyHighPercent"]).To(tideResultsPatientMatcher(timeInAnyHighAndUp))
+					Expect(report.Results["timeInAnyHighPercent"]).To(matchTIDEPatients(timeInAnyHighAndUp))
 				})
+			})
+
+			Describe("Boundaries", func() {
+				var roundedClinicID primitive.ObjectID
+				var tags []string
+				var period string
+				var cutoff time.Time
+				var params patients.TideReportParams
+				BeforeEach(func() {
+					roundedClinicID = primitive.NewObjectID()
+					tags = []string{"aaaaaaaaaaaaaaaaaaaaaaaa"}
+					period = "14d"
+					cutoff = time.Date(2025, time.July, 1, 0, 0, 0, 0, time.UTC)
+					params = patients.TideReportParams{
+						Period:         period,
+						Tags:           slices.Clone(tags),
+						LastDataCutoff: cutoff,
+					}
+				})
+				AfterEach(func() {
+					_, err := collection.DeleteMany(context.Background(), primitive.M{"clinicId": roundedClinicID})
+					Expect(err).To(Succeed())
+				})
+
+				DescribeTable("Rounded values", func(tideTest roundedTIDEReportTest) {
+					ctx := context.Background()
+					var docs []any
+					for _, patient := range tideTest.Patients {
+						patient.ClinicID = roundedClinicID
+						patient.Tags = tags
+						docs = append(docs, newPatient14dSummary(patient))
+					}
+					_, err := collection.InsertMany(ctx, docs)
+					Expect(err).ToNot(HaveOccurred())
+					report, err := repo.TideReport(ctx, roundedClinicID.Hex(), params)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(report.Results).To(matchTIDECategories(tideTest.ExpectedPatients))
+				},
+					Entry("timeInVeryLow rounded up", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "very+low@tidepool.org",
+								FullName: "Very Low",
+								UserID:   "111111",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:   4.0,
+									LastData:             time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:    0.85,
+									TimeInTargetPercent:  0.959,
+									TimeInLowPercent:     0.035,
+									TimeInVeryLowPercent: 0.006,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"timeInVeryLowPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("very+low@tidepool.org"),
+										FullName: strp("Very Low"),
+										Id:       strp("111111"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:   floatp(4.0),
+									TimeInTargetPercent:  floatp(0.959),
+									TimeCGMUseMinutes:    intp(0.85 * maxMinutes14d),
+									TimeCGMUsePercent:    floatp(0.85),
+									TimeInLowPercent:     floatp(0.035),
+									TimeInVeryLowPercent: floatp(0.006),
+									LastData:             mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInVeryLow rounded up, priority over timeInAnyLow", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "very+low2@tidepool.org",
+								FullName: "Very Low II",
+								UserID:   "211111",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:   3.5,
+									LastData:             time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:    0.85,
+									TimeInTargetPercent:  0.9548,
+									TimeInLowPercent:     0.0401,
+									TimeInVeryLowPercent: 0.0051,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"timeInVeryLowPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("very+low2@tidepool.org"),
+										FullName: strp("Very Low II"),
+										Id:       strp("211111"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:   floatp(3.5),
+									TimeInTargetPercent:  floatp(0.9548),
+									TimeCGMUseMinutes:    intp(0.85 * maxMinutes14d),
+									TimeCGMUsePercent:    floatp(0.85),
+									TimeInLowPercent:     floatp(0.0401),
+									TimeInVeryLowPercent: floatp(0.0051),
+									LastData:             mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInVeryLow exactly 0.5%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "exactly+not+very+low@tidepool.org",
+								FullName: "Exactly Not Very Low",
+								UserID:   "111112",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:   4.0,
+									LastData:             time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:    0.85,
+									TimeInTargetPercent:  0.995,
+									TimeInVeryLowPercent: 0.005,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("exactly+not+very+low@tidepool.org"),
+										FullName: strp("Exactly Not Very Low"),
+										Id:       strp("111112"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:   floatp(4.0),
+									TimeInTargetPercent:  floatp(0.995),
+									TimeCGMUseMinutes:    intp(0.85 * maxMinutes14d),
+									TimeCGMUsePercent:    floatp(0.85),
+									TimeInVeryLowPercent: floatp(0.005),
+									LastData:             mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInVeryLow < 0.5%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "not+very+low@tidepool.org",
+								FullName: "Not Very Low",
+								UserID:   "111113",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:   3.99,
+									LastData:             time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:    0.90,
+									TimeInTargetPercent:  0.964,
+									TimeInLowPercent:     0.032,
+									TimeInVeryLowPercent: 0.004,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("not+very+low@tidepool.org"),
+										FullName: strp("Not Very Low"),
+										Id:       strp("111113"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:   floatp(3.99),
+									TimeInTargetPercent:  floatp(0.964),
+									TimeCGMUseMinutes:    intp(0.90 * maxMinutes14d),
+									TimeCGMUsePercent:    floatp(0.90),
+									TimeInVeryLowPercent: floatp(0.004),
+									TimeInLowPercent:     floatp(0.032),
+									TimeInAnyLowPercent:  floatp(0.032),
+									LastData:             mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInLow exactly 4%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "low+4@tidepool.org",
+								FullName: "Low 4%",
+								UserID:   "111114",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  3.93,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.80,
+									TimeInTargetPercent: 0.96,
+									TimeInLowPercent:    0.04,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"timeInAnyLowPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("low+4@tidepool.org"),
+										FullName: strp("Low 4%"),
+										Id:       strp("111114"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(3.93),
+									TimeInTargetPercent: floatp(0.96),
+									TimeCGMUseMinutes:   intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:   floatp(0.80),
+									TimeInLowPercent:    floatp(0.04),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("Change in TIR < (negative) 15%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "change+tir@tidepool.org",
+								FullName: "Change TIR",
+								UserID:   "111119",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:       3.8,
+									LastData:                 time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:        0.80,
+									TimeInTargetPercent:      0.97,
+									TimeInLowPercent:         0.03,
+									TimeInTargetPercentDelta: -0.16,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"dropInTimeInTargetPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("change+tir@tidepool.org"),
+										FullName: strp("Change TIR"),
+										Id:       strp("111119"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:       floatp(3.8),
+									TimeInTargetPercent:      floatp(0.97),
+									TimeCGMUseMinutes:        intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:        floatp(0.80),
+									TimeInLowPercent:         floatp(0.03),
+									TimeInTargetPercentDelta: floatp(-0.16),
+									LastData:                 mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("Change in TIR exactly (negative) 15%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "change+tir+exact@tidepool.org",
+								FullName: "Change TIR Exact",
+								UserID:   "111120",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:       3.8,
+									LastData:                 time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:        0.80,
+									TimeInTargetPercent:      0.97,
+									TimeInLowPercent:         0.03,
+									TimeInTargetPercentDelta: -0.15,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"dropInTimeInTargetPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("change+tir+exact@tidepool.org"),
+										FullName: strp("Change TIR Exact"),
+										Id:       strp("111120"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:       floatp(3.8),
+									TimeInTargetPercent:      floatp(0.97),
+									TimeCGMUseMinutes:        intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:        floatp(0.80),
+									TimeInLowPercent:         floatp(0.03),
+									TimeInTargetPercentDelta: floatp(-0.15),
+									LastData:                 mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("Change in TIR greater than -15%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "change+tir+14@tidepool.org",
+								FullName: "Change TIR 14",
+								UserID:   "111121",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:       3.8,
+									LastData:                 time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:        0.80,
+									TimeInTargetPercent:      0.97,
+									TimeInLowPercent:         0.03,
+									TimeInTargetPercentDelta: -0.14,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("change+tir+14@tidepool.org"),
+										FullName: strp("Change TIR 14"),
+										Id:       strp("111121"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:       floatp(3.8),
+									TimeInTargetPercent:      floatp(0.97),
+									TimeCGMUseMinutes:        intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:        floatp(0.80),
+									TimeInLowPercent:         floatp(0.03),
+									TimeInTargetPercentDelta: floatp(-0.14),
+									LastData:                 mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInHigh < 25%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "time+high+less+25@tidepool.org",
+								FullName: "time high",
+								UserID:   "22211a",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.5,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.80,
+									TimeInTargetPercent: 0.76,
+									TimeInHighPercent:   0.24,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("time+high+less+25@tidepool.org"),
+										FullName: strp("time high"),
+										Id:       strp("22211a"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.5),
+									TimeInTargetPercent: floatp(0.76),
+									TimeInHighPercent:   floatp(0.24),
+									TimeCGMUseMinutes:   intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:   floatp(0.80),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInHigh rounded down < 25%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "time+high+rounded+down@tidepool.org",
+								FullName: "time high",
+								UserID:   "222119",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.5,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.80,
+									TimeInTargetPercent: 0.756,
+									TimeInHighPercent:   0.244,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("time+high+rounded+down@tidepool.org"),
+										FullName: strp("time high"),
+										Id:       strp("222119"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.5),
+									TimeInTargetPercent: floatp(0.756),
+									TimeInHighPercent:   floatp(0.244),
+									TimeCGMUseMinutes:   intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:   floatp(0.80),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInHigh rounded ≥ 25%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "time+high+rounded+up@tidepool.org",
+								FullName: "Time High",
+								UserID:   "222120",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.5,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.80,
+									TimeInTargetPercent: 0.7544,
+									TimeInHighPercent:   0.2456,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"timeInAnyHighPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("time+high+rounded+up@tidepool.org"),
+										FullName: strp("Time High"),
+										Id:       strp("222120"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.5),
+									TimeInTargetPercent: floatp(0.7544),
+									TimeInHighPercent:   floatp(0.2456),
+									TimeCGMUseMinutes:   intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:   floatp(0.80),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("timeInHigh exactly 25%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "time+high+exact@tidepool.org",
+								FullName: "Time High",
+								UserID:   "222120",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.5,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.80,
+									TimeInTargetPercent: 0.75,
+									TimeInHighPercent:   0.25,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"timeInAnyHighPercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("time+high+exact@tidepool.org"),
+										FullName: strp("Time High"),
+										Id:       strp("222120"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.5),
+									TimeInTargetPercent: floatp(0.75),
+									TimeInHighPercent:   floatp(0.25),
+									TimeCGMUseMinutes:   intp(0.80 * maxMinutes14d),
+									TimeCGMUsePercent:   floatp(0.80),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("CGM Wear Time ≥ 70%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "cgm+wear@tidepool.org",
+								FullName: "CGM Wear",
+								UserID:   "33311a",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:   4.4,
+									LastData:             time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:    0.71,
+									TimeInTargetPercent:  0.969,
+									TimeInLowPercent:     0.03,
+									TimeInVeryLowPercent: 0.001,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("cgm+wear@tidepool.org"),
+										FullName: strp("CGM Wear"),
+										Id:       strp("33311a"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:   floatp(4.4),
+									TimeInTargetPercent:  floatp(0.969),
+									TimeInLowPercent:     floatp(0.03),
+									TimeInVeryLowPercent: floatp(0.001),
+									TimeCGMUseMinutes:    intp(int(math.Floor(maxMinutes14d * 0.71))),
+									TimeCGMUsePercent:    floatp(0.71),
+									LastData:             mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("CGM Wear Time exactly 70%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "cgm+wear+70@tidepool.org",
+								FullName: "CGM Wear",
+								UserID:   "33311b",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.4,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.70,
+									TimeInTargetPercent: 0.97,
+									TimeInLowPercent:    0.03,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("cgm+wear+70@tidepool.org"),
+										FullName: strp("CGM Wear"),
+										Id:       strp("33311b"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.4),
+									TimeInTargetPercent: floatp(0.97),
+									TimeInLowPercent:    floatp(0.03),
+									TimeCGMUseMinutes:   intp(int(math.Floor(maxMinutes14d * 0.70))),
+									TimeCGMUsePercent:   floatp(0.70),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("CGM Wear Time rounded up ≥ 70%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "cgm+wear+rounded+up+70@tidepool.org",
+								FullName: "CGM Wear",
+								UserID:   "33311c",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.4,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.699,
+									TimeInTargetPercent: 0.97,
+									TimeInLowPercent:    0.03,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("cgm+wear+rounded+up+70@tidepool.org"),
+										FullName: strp("CGM Wear"),
+										Id:       strp("33311c"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.4),
+									TimeInTargetPercent: floatp(0.97),
+									TimeInLowPercent:    floatp(0.03),
+									TimeCGMUseMinutes:   intp(int(math.Floor(maxMinutes14d * 0.699))),
+									TimeCGMUsePercent:   floatp(0.699),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("CGM Wear Time exactly 69.5% rounds to ≥ 70%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "cgm+wear+exactly+695@tidepool.org",
+								FullName: "CGM Wear",
+								UserID:   "33311d",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.4,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.695,
+									TimeInTargetPercent: 0.97,
+									TimeInLowPercent:    0.03,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"meetingTargets": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("cgm+wear+exactly+695@tidepool.org"),
+										FullName: strp("CGM Wear"),
+										Id:       strp("33311d"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.4),
+									TimeInTargetPercent: floatp(0.97),
+									TimeInLowPercent:    floatp(0.03),
+									TimeCGMUseMinutes:   intp(int(math.Floor(maxMinutes14d * 0.695))),
+									TimeCGMUsePercent:   floatp(0.695),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+					Entry("69% < CGM Wear Time < 69.5% rounds to < 70%", roundedTIDEReportTest{
+						Patients: []patientWithSummary{
+							{
+								Email:    "cgm+wear+lt+695@tidepool.org",
+								FullName: "CGM Wear",
+								UserID:   "33311e",
+								patientSummaryPeriod: patientSummaryPeriod{
+									AverageGlucoseMmol:  4.4,
+									LastData:            time.Date(2025, time.July, 13, 0, 0, 0, 0, time.UTC),
+									TimeCGMUsePercent:   0.694,
+									TimeInTargetPercent: 0.97,
+									TimeInLowPercent:    0.03,
+								},
+							},
+						},
+						ExpectedPatients: map[string][]patients.TideResultPatient{
+							"timeCGMUsePercent": []patients.TideResultPatient{
+								{
+									Patient: patients.TidePatient{
+										Email:    strp("cgm+wear+lt+695@tidepool.org"),
+										FullName: strp("CGM Wear"),
+										Id:       strp("33311e"),
+										Tags:     tags,
+									},
+									AverageGlucoseMmol:  floatp(4.4),
+									TimeInTargetPercent: floatp(0.97),
+									TimeInLowPercent:    floatp(0.03),
+									TimeCGMUseMinutes:   intp(int(math.Floor(maxMinutes14d * 0.694))),
+									TimeCGMUsePercent:   floatp(0.694),
+									LastData:            mustTime("2025-07-13T00:00:00.000Z"),
+								},
+							},
+						},
+					}),
+				)
 			})
 		})
 	})
@@ -3050,7 +3687,7 @@ func testLogger() *zap.SugaredLogger {
 	return zap.New(core).Sugar()
 }
 
-func tideResultsPatientMatcher(results []patients.TideResultPatient) types.GomegaMatcher {
+func matchTIDEPatients(results []patients.TideResultPatient) types.GomegaMatcher {
 	matches := make([]types.GomegaMatcher, 0, len(results))
 	for result := range slices.Values(results) {
 		matches = append(matches, tideResultPatientMatcher(result))
@@ -3058,25 +3695,65 @@ func tideResultsPatientMatcher(results []patients.TideResultPatient) types.Gomeg
 	return ConsistOf(matches)
 }
 
+func matchTIDECategories(categories map[string][]patients.TideResultPatient) types.GomegaMatcher {
+	var matchers []types.GomegaMatcher
+	for category, patients := range categories {
+		if len(patients) > 0 {
+			matchers = append(matchers, HaveKeyWithValue(category, matchTIDEPatients(patients)))
+		}
+	}
+	return And(matchers...)
+}
+
 func tideResultPatientMatcher(result patients.TideResultPatient) types.GomegaMatcher {
 	fields := Fields{
 		"AverageGlucoseMmol":         PointTo(BeNumerically(`~`, *result.AverageGlucoseMmol, math.SmallestNonzeroFloat64)),
 		"Patient":                    tidePatientMatcher(result.Patient),
-		"TimeCGMUseMinutes":          PointTo(BeNumerically(`~`, *result.TimeCGMUseMinutes, math.SmallestNonzeroFloat64)),
-		"TimeCGMUsePercent":          PointTo(BeNumerically(`~`, *result.TimeCGMUsePercent, math.SmallestNonzeroFloat64)),
-		"TimeInHighPercent":          PointTo(BeNumerically(`~`, *result.TimeInHighPercent, math.SmallestNonzeroFloat64)),
-		"TimeInLowPercent":           PointTo(BeNumerically(`~`, *result.TimeInLowPercent, math.SmallestNonzeroFloat64)),
-		"TimeInTargetPercent":        PointTo(BeNumerically(`~`, *result.TimeInTargetPercent, math.SmallestNonzeroFloat64)),
-		"TimeInTargetPercentDelta":   PointTo(BeNumerically(`~`, *result.TimeInTargetPercentDelta, math.SmallestNonzeroFloat64)),
-		"TimeInVeryHighPercent":      PointTo(BeNumerically(`~`, *result.TimeInVeryHighPercent, math.SmallestNonzeroFloat64)),
-		"TimeInVeryLowPercent":       PointTo(BeNumerically(`~`, *result.TimeInVeryLowPercent, math.SmallestNonzeroFloat64)),
-		"TimeInAnyHighPercent":       PointTo(BeNumerically(`~`, *result.TimeInAnyHighPercent, math.SmallestNonzeroFloat64)),
-		"TimeInAnyLowPercent":        PointTo(BeNumerically(`~`, *result.TimeInAnyLowPercent, math.SmallestNonzeroFloat64)),
+		"TimeCGMUseMinutes":          Ignore(),
+		"TimeCGMUsePercent":          Ignore(),
+		"TimeInHighPercent":          Ignore(),
+		"TimeInLowPercent":           Ignore(),
+		"TimeInTargetPercent":        Ignore(),
+		"TimeInTargetPercentDelta":   Ignore(),
+		"TimeInVeryHighPercent":      Ignore(),
+		"TimeInVeryLowPercent":       Ignore(),
+		"TimeInAnyHighPercent":       Ignore(),
+		"TimeInAnyLowPercent":        Ignore(),
 		"LastData":                   Ignore(),
 		"GlucoseManagementIndicator": Ignore(),
 		"TimeInExtremeHighPercent":   Ignore(),
 	}
 	// May be nil
+	if result.TimeCGMUseMinutes != nil {
+		fields["TimeCGMUseMinutes"] = PointTo(BeNumerically(`~`, *result.TimeCGMUseMinutes, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeCGMUsePercent != nil {
+		fields["TimeCGMUsePercent"] = PointTo(BeNumerically(`~`, *result.TimeCGMUsePercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInHighPercent != nil {
+		fields["TimeInHighPercent"] = PointTo(BeNumerically(`~`, *result.TimeInHighPercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInLowPercent != nil {
+		fields["TimeInLowPercent"] = PointTo(BeNumerically(`~`, *result.TimeInLowPercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInTargetPercent != nil {
+		fields["TimeInTargetPercent"] = PointTo(BeNumerically(`~`, *result.TimeInTargetPercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInTargetPercentDelta != nil {
+		fields["TimeInTargetPercentDelta"] = PointTo(BeNumerically(`~`, *result.TimeInTargetPercentDelta, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInVeryHighPercent != nil {
+		fields["TimeInVeryHighPercent"] = PointTo(BeNumerically(`~`, *result.TimeInVeryHighPercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInVeryLowPercent != nil {
+		fields["TimeInVeryLowPercent"] = PointTo(BeNumerically(`~`, *result.TimeInVeryLowPercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInAnyHighPercent != nil {
+		fields["TimeInAnyHighPercent"] = PointTo(BeNumerically(`~`, *result.TimeInAnyHighPercent, math.SmallestNonzeroFloat64))
+	}
+	if result.TimeInAnyLowPercent != nil {
+		fields["TimeInAnyLowPercent"] = PointTo(BeNumerically(`~`, *result.TimeInAnyLowPercent, math.SmallestNonzeroFloat64))
+	}
 	if result.GlucoseManagementIndicator != nil {
 		fields["GlucoseManagementIndicator"] = PointTo(BeNumerically(`~`, *result.GlucoseManagementIndicator, math.SmallestNonzeroFloat64))
 	}
@@ -3132,4 +3809,236 @@ func mustTime(tim string) *time.Time {
 		panic(err)
 	}
 	return &t
+}
+
+type roundedTIDEReportTest struct {
+	Patients         []patientWithSummary
+	ExpectedPatients map[string][]patients.TideResultPatient
+}
+
+// patientWithSummary is a minimal subset of a patient with just enough
+// information to retrieve TIDE results for.
+type patientWithSummary struct {
+	ClinicID primitive.ObjectID
+	Email    string
+	FullName string
+	UserID   string
+	Tags     []string
+	patientSummaryPeriod
+}
+
+// patientSummaryPeriod is a minimal subset of data in a summary period that
+// has just enough information for TIDE summary comparisons. Only relevant
+// fields need to be set. E.g., if a user does not have any time in low
+// percent, it may be left to the zero value.
+type patientSummaryPeriod struct {
+	AverageGlucoseMmol       float64
+	LastData                 time.Time
+	TimeCGMUsePercent        float64
+	TimeInExtremeHighPercent float64
+	TimeInHighPercent        float64
+	TimeInLowMinutes         int
+	TimeInLowPercent         float64
+	TimeInTargetPercent      float64
+	TimeInVeryHighMinutes    int
+	TimeInVeryHighPercent    float64
+	TimeInVeryLowMinutes     int
+	TimeInVeryLowPercent     float64
+	TimeInTargetPercentDelta float64 // DropInTimeInTargetPercent
+}
+
+func newPatient14dSummary(patient patientWithSummary) *patients.Patient {
+	summary := patient.patientSummaryPeriod
+	averageDailyRecords := float64(216)
+	epsilon := math.SmallestNonzeroFloat64
+	timeInAnyLowPercent := summary.TimeInLowPercent
+	hasTimeInAnyLow := timeInAnyLowPercent > epsilon
+	timeInAnyHighPercent := summary.TimeInHighPercent + summary.TimeInExtremeHighPercent
+	hasTimeInAnyHigh := timeInAnyHighPercent > epsilon
+	hasTimeInLow := summary.TimeInLowPercent > epsilon
+	hasTimeInVeryLow := summary.TimeInVeryLowPercent > epsilon
+	hasTimeInHigh := summary.TimeInHighPercent > epsilon
+	hasTimeInExtremeHigh := summary.TimeInExtremeHighPercent > epsilon
+	hasTimeCGMUse := summary.TimeCGMUsePercent > epsilon
+	hasTimeInTarget := summary.TimeInTargetPercent > epsilon
+
+	daysWithData := 14
+	numMinutes := maxMinutes14d
+	numRecords := maxRecords14d
+	hoursWithData := daysWithData * 14
+	if hasTimeCGMUse {
+		numMinutes = int(float64(maxMinutes14d) * summary.TimeCGMUsePercent)
+		numRecords = int(float64(maxRecords14d) * summary.TimeCGMUsePercent)
+		daysWithData = int(14 * summary.TimeCGMUsePercent)
+		hoursWithData = int(float64(daysWithData) * 24.0 * summary.TimeCGMUsePercent)
+	}
+	var patientTags []primitive.ObjectID
+	if len(patient.Tags) > 0 {
+		for _, tag := range patient.Tags {
+			patientTags = append(patientTags, *mustObjectID(tag))
+		}
+	}
+	period14d := patients.PatientCGMPeriod{
+		AverageDailyRecords:             &averageDailyRecords,
+		AverageGlucoseMmol:              floatp(summary.AverageGlucoseMmol),
+		AverageGlucoseMmolDelta:         nil,
+		CoefficientOfVariation:          0.0,
+		CoefficientOfVariationDelta:     0.0,
+		DaysWithData:                    daysWithData,
+		DaysWithDataDelta:               0,
+		GlucoseManagementIndicator:      nil,
+		GlucoseManagementIndicatorDelta: nil,
+		HasAverageDailyRecords:          true,
+		HasAverageGlucoseMmol:           summary.AverageGlucoseMmol >= math.SmallestNonzeroFloat64,
+		HasGlucoseManagementIndicator:   false,
+		HasTimeCGMUseMinutes:            hasTimeCGMUse,
+		HasTimeCGMUsePercent:            hasTimeCGMUse,
+		HasTimeCGMUseRecords:            hasTimeCGMUse,
+		HasTimeInAnyHighMinutes:         hasTimeInAnyHigh,
+		HasTimeInAnyHighPercent:         hasTimeInAnyHigh,
+		HasTimeInAnyHighRecords:         hasTimeInAnyHigh,
+		HasTimeInAnyLowMinutes:          hasTimeInAnyLow,
+		HasTimeInAnyLowPercent:          hasTimeInAnyLow,
+		HasTimeInAnyLowRecords:          hasTimeInAnyLow,
+		HasTimeInExtremeHighMinutes:     hasTimeInExtremeHigh,
+		HasTimeInExtremeHighPercent:     hasTimeInExtremeHigh,
+		HasTimeInExtremeHighRecords:     hasTimeInExtremeHigh,
+		HasTimeInHighMinutes:            hasTimeInHigh,
+		HasTimeInHighPercent:            hasTimeInHigh,
+		HasTimeInHighRecords:            hasTimeInHigh,
+		HasTimeInLowMinutes:             hasTimeInLow,
+		HasTimeInLowPercent:             hasTimeInLow,
+		HasTimeInLowRecords:             hasTimeInLow,
+		HasTimeInTargetMinutes:          hasTimeInTarget,
+		HasTimeInTargetPercent:          hasTimeInTarget,
+		HasTimeInTargetRecords:          hasTimeInTarget,
+		HasTimeInVeryLowMinutes:         hasTimeInVeryLow,
+		HasTimeInVeryLowPercent:         hasTimeInVeryLow,
+		HasTimeInVeryLowRecords:         hasTimeInVeryLow,
+		HasTotalRecords:                 true,
+		HoursWithData:                   hoursWithData,
+		HoursWithDataDelta:              0,
+		Max:                             0.0,
+		MaxDelta:                        0.0,
+		Min:                             0.0,
+		MinDelta:                        0.0,
+		StandardDeviation:               0.0,
+		StandardDeviationDelta:          0.0,
+		TimeCGMUseMinutesDelta:          nil,
+		TimeCGMUsePercent:               floatp(summary.TimeCGMUsePercent),
+		TimeCGMUsePercentDelta:          nil,
+		TimeCGMUseRecordsDelta:          nil,
+		TimeInAnyHighMinutesDelta:       nil,
+		TimeInAnyHighPercent:            floatp(timeInAnyHighPercent),
+		TimeInAnyHighPercentDelta:       nil,
+		TimeInAnyHighRecordsDelta:       nil,
+		TimeInAnyLowMinutesDelta:        nil,
+		TimeInAnyLowPercent:             floatp(timeInAnyLowPercent),
+		TimeInAnyLowPercentDelta:        nil,
+		TimeInAnyLowRecordsDelta:        nil,
+		TimeInExtremeHighMinutesDelta:   nil,
+		TimeInExtremeHighPercent:        nil,
+		TimeInExtremeHighPercentDelta:   nil,
+		TimeInExtremeHighRecords:        nil,
+		TimeInExtremeHighRecordsDelta:   nil,
+		TimeInHighMinutesDelta:          nil,
+		TimeInHighPercent:               floatp(summary.TimeInHighPercent),
+		TimeInHighPercentDelta:          nil,
+		TimeInHighRecordsDelta:          nil,
+		TimeInLowMinutesDelta:           nil,
+		TimeInLowPercent:                floatp(summary.TimeInLowPercent),
+		TimeInLowPercentDelta:           nil,
+		TimeInLowRecordsDelta:           nil,
+		TimeInTargetMinutesDelta:        nil,
+		TimeInTargetPercent:             floatp(summary.TimeInTargetPercent),
+		TimeInTargetPercentDelta:        floatp(summary.TimeInTargetPercentDelta),
+		TimeInTargetRecordsDelta:        nil,
+		TimeInVeryHighMinutesDelta:      nil,
+		TimeInVeryHighPercent:           floatp(summary.TimeInVeryHighPercent),
+		TimeInVeryHighPercentDelta:      nil,
+		TimeInVeryHighRecordsDelta:      nil,
+		TimeInVeryLowMinutesDelta:       nil,
+		TimeInVeryLowPercent:            floatp(summary.TimeInVeryLowPercent),
+		TimeInVeryLowPercentDelta:       nil,
+		TimeInVeryLowRecordsDelta:       nil,
+		TotalRecords:                    intp(numRecords),
+		TotalRecordsDelta:               nil,
+	}
+	if hasTimeInTarget {
+		period14d.TimeInTargetRecords = intp(int(summary.TimeInTargetPercent * float64(numRecords)))
+		period14d.TimeInTargetMinutes = intp(int(summary.TimeInTargetPercent * float64(numMinutes)))
+		if summary.TimeInTargetPercentDelta < -epsilon {
+			period14d.TimeInTargetPercentDelta = floatp(summary.TimeInTargetPercentDelta)
+		}
+	}
+	if hasTimeInExtremeHigh {
+		period14d.TimeInExtremeHighRecords = intp(int(summary.TimeInExtremeHighPercent * float64(numRecords)))
+		period14d.TimeInExtremeHighMinutes = intp(int(summary.TimeInExtremeHighPercent * float64(numMinutes)))
+	}
+	if hasTimeInAnyLow {
+		period14d.TimeInAnyLowRecords = intp(int(timeInAnyLowPercent * float64(numRecords)))
+		period14d.TimeInAnyLowMinutes = intp(int(timeInAnyLowPercent * float64(numMinutes)))
+	}
+	if hasTimeInAnyHigh {
+		period14d.TimeInAnyHighRecords = intp(int(timeInAnyHighPercent * float64(numRecords)))
+		period14d.TimeInAnyHighMinutes = intp(int(timeInAnyHighPercent * float64(numMinutes)))
+	}
+	if hasTimeCGMUse {
+		period14d.TimeCGMUseRecords = &numRecords
+		period14d.TimeCGMUseMinutes = &numMinutes
+	}
+	if hasTimeInHigh {
+		period14d.TimeInHighMinutes = intp(int(summary.TimeInHighPercent * float64(numRecords)))
+		period14d.TimeInHighRecords = intp(int(summary.TimeInHighPercent * float64(numMinutes)))
+	}
+	if hasTimeInLow {
+		period14d.TimeInLowMinutes = intp(int(summary.TimeInLowPercent * float64(numRecords)))
+		period14d.TimeInLowRecords = intp(int(summary.TimeInLowPercent * float64(numMinutes)))
+	}
+	if hasTimeInVeryLow {
+		period14d.TimeInVeryLowMinutes = intp(int(summary.TimeInVeryLowPercent * float64(numRecords)))
+		period14d.TimeInVeryLowRecords = intp(int(summary.TimeInVeryLowPercent * float64(numMinutes)))
+	}
+	var lastData *time.Time
+	hasLastData := !summary.LastData.IsZero()
+	if hasLastData {
+		lastData = &summary.LastData
+	}
+	return &patients.Patient{
+		ClinicId: &patient.ClinicID,
+		UserId:   &patient.UserID,
+		Email:    &patient.Email,
+		FullName: &patient.FullName,
+		Tags:     &patientTags,
+		Summary: &patients.Summary{
+			CGM: &patients.PatientCGMStats{
+				Id: primitive.NewObjectID().Hex(),
+				Config: patients.PatientSummaryConfig{
+					HighGlucoseThreshold:     patients.HighGlucoseThreshold,
+					LowGlucoseThreshold:      patients.LowGlucoseThreshold,
+					SchemaVersion:            patients.TideSchemaVersion,
+					VeryHighGlucoseThreshold: patients.VeryHighGlucoseThreshold,
+					VeryLowGlucoseThreshold:  patients.VeryLowGlucoseThreshold,
+				},
+				Dates: patients.PatientSummaryDates{
+					FirstData:          &time.Time{},
+					HasFirstData:       false,
+					HasLastData:        hasLastData,
+					HasLastUploadDate:  false,
+					HasOutdatedSince:   false,
+					LastData:           lastData,
+					LastUpdatedDate:    &time.Time{},
+					LastUpdatedReason:  nil,
+					LastUploadDate:     &time.Time{},
+					OutdatedReason:     nil,
+					OutdatedSince:      &time.Time{},
+					OutdatedSinceLimit: &time.Time{},
+				},
+				Periods: map[string]patients.PatientCGMPeriod{
+					"14d": period14d,
+				},
+			},
+			BGM: &patients.PatientBGMStats{},
+		},
+	}
 }

--- a/patients/repository/repository_test.go
+++ b/patients/repository/repository_test.go
@@ -2906,7 +2906,7 @@ var _ = Describe("TideReport", func() {
 				})
 			})
 
-			Describe("Boundaries", func() {
+			Describe("Rounding", func() {
 				var roundedClinicID primitive.ObjectID
 				var tags []string
 				var period string

--- a/patients/repository/repository_test.go
+++ b/patients/repository/repository_test.go
@@ -2160,20 +2160,40 @@ var _ = Describe("TideReport", func() {
 							TimeInAnyLowPercent:      floatp(1),
 							LastData:                 mustTime("2025-07-31T10:24:00.359Z"),
 						},
+						{
+							Patient: patients.TidePatient{
+								Email:    strp("rounded+very+low@tidepool.org"),
+								FullName: strp("Rounded Time In Very Low ≥ 1%"),
+								Id:       strp("aaaaaaaa-bbbb-cccc-dddd-dddddddddddd"),
+								Tags:     []string{"aaaaaaaaaaaaaaaaaaaaaaaa"},
+							},
+							AverageGlucoseMmol:       floatp(2.681029437218411),
+							TimeCGMUseMinutes:        intp(14070),
+							TimeCGMUsePercent:        floatp(0.8839895693808708),
+							TimeInHighPercent:        floatp(0),
+							TimeInLowPercent:         floatp(0.035),
+							TimeInTargetPercent:      floatp(0.905),
+							TimeInTargetPercentDelta: floatp(0),
+							TimeInVeryHighPercent:    floatp(0),
+							TimeInVeryLowPercent:     floatp(0.06),
+							TimeInAnyHighPercent:     floatp(0),
+							TimeInAnyLowPercent:      floatp(0.095),
+							LastData:                 mustTime("2025-07-04T14:49:07.079Z"),
+						},
 					}
 					timeInAnyLowPercentResults = []patients.TideResultPatient{
 						{
 							AverageGlucoseMmol: floatp(3.8945273631840798),
 							Patient: patients.TidePatient{
 								Email:       strp("time+in+low+4+pct@tidepool.org"),
-								FullName:    strp("Time below 3.9 mmol/L > 4%"),
+								FullName:    strp("Time below 3.9 mmol/L ≥ 4%"),
 								Id:          strp("aaaaaaaa-bbbb-cccc-dddd-aaaaaaaa4444"),
 								Tags:        []string{"aaaaaaaaaaaaaaaaaaaaaaaa"},
 								Reviews:     nil,
 								DataSources: nil,
 							},
 							TimeCGMUseMinutes:        intp(14070),
-							TimeCGMUsePercent:        floatp(0.6979166666666666),
+							TimeCGMUsePercent:        floatp(0.694),
 							TimeInHighPercent:        floatp(0),
 							TimeInLowPercent:         floatp(0.05472636815920398),
 							TimeInTargetPercent:      floatp(0.945273631840796),
@@ -2183,6 +2203,28 @@ var _ = Describe("TideReport", func() {
 							TimeInAnyHighPercent:     floatp(0),
 							TimeInAnyLowPercent:      floatp(0.05472636815920398),
 							LastData:                 mustTime("2025-07-03T14:49:07.079Z"),
+						},
+						{
+							AverageGlucoseMmol: floatp(3.9782035652530548),
+							Patient: patients.TidePatient{
+								Email:       strp("time+in+rounded+low@tidepool.org"),
+								FullName:    strp("Rounded Time In Low ≥ 4%"),
+								Id:          strp("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+								Tags:        []string{"aaaaaaaaaaaaaaaaaaaaaaaa"},
+								Reviews:     nil,
+								DataSources: nil,
+							},
+							TimeCGMUseMinutes:        intp(14070),
+							TimeCGMUsePercent:        floatp(0.7625795277794299),
+							TimeInHighPercent:        floatp(0),
+							TimeInLowPercent:         floatp(0.039),
+							TimeInTargetPercent:      floatp(0.957),
+							TimeInTargetPercentDelta: floatp(0),
+							TimeInVeryHighPercent:    floatp(0),
+							TimeInVeryLowPercent:     floatp(0.004),
+							TimeInAnyHighPercent:     floatp(0),
+							TimeInAnyLowPercent:      floatp(0.043),
+							LastData:                 mustTime("2025-07-05T15:50:07.000Z"),
 						},
 					}
 					timeInVeryHighResults = []patients.TideResultPatient{
@@ -2331,7 +2373,7 @@ var _ = Describe("TideReport", func() {
 							TimeInTargetPercent:      floatp(0.976303317535545),
 							TimeInTargetPercentDelta: floatp(0.022936733994397884),
 							TimeInVeryHighPercent:    floatp(0),
-							TimeInVeryLowPercent:     floatp(0.0074831628835120975),
+							TimeInVeryLowPercent:     floatp(0.0044831628835120975),
 							TimeInAnyHighPercent:     floatp(0.001995510102269893),
 							TimeInAnyLowPercent:      floatp(0.021701172362185085),
 							LastData:                 mustTime("2025-07-07T16:38:39.206Z"),
@@ -2374,7 +2416,7 @@ var _ = Describe("TideReport", func() {
 							TimeInTargetPercent:      floatp(0.976303317535545),
 							TimeInTargetPercentDelta: floatp(0.022936733994397884),
 							TimeInVeryHighPercent:    floatp(0),
-							TimeInVeryLowPercent:     floatp(0.0074831628835120975),
+							TimeInVeryLowPercent:     floatp(0.0044831628835120975),
 							TimeInAnyHighPercent:     floatp(0.001995510102269893),
 							TimeInAnyLowPercent:      floatp(0.021701172362185085),
 							LastData:                 mustTime("2025-07-07T16:38:39.206Z"),
@@ -2389,7 +2431,7 @@ var _ = Describe("TideReport", func() {
 							AverageGlucoseMmol:       floatp(5.300278257324843),
 							TimeCGMUseMinutes:        intp(19625),
 							TimeCGMUsePercent:        floatp(0.9734623015873016),
-							TimeInHighPercent:        floatp(0.06929936305732484),
+							TimeInHighPercent:        floatp(0.02929936305732484),
 							TimeInLowPercent:         floatp(0.006878980891719746),
 							TimeInTargetPercent:      floatp(0.8991082802547771),
 							TimeInTargetPercentDelta: floatp(0.008514718886567851),
@@ -2438,8 +2480,8 @@ var _ = Describe("TideReport", func() {
 					Expect(err).ToNot(HaveOccurred())
 					numResultCategories := 8
 					Expect(len(report.Results)).To(Equal(numResultCategories))
-					Expect(report.Metadata.CandidatePatients).To(Equal(11))
-					Expect(report.Metadata.SelectedPatients).To(Equal(11))
+					Expect(report.Metadata.CandidatePatients).To(Equal(13))
+					Expect(report.Metadata.SelectedPatients).To(Equal(13))
 
 					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
 
@@ -2467,8 +2509,8 @@ var _ = Describe("TideReport", func() {
 					Expect(err).ToNot(HaveOccurred())
 					numResultCategories := 8
 					Expect(len(report.Results)).To(Equal(numResultCategories))
-					Expect(report.Metadata.CandidatePatients).To(Equal(11))
-					Expect(report.Metadata.SelectedPatients).To(Equal(11))
+					Expect(report.Metadata.CandidatePatients).To(Equal(13))
+					Expect(report.Metadata.SelectedPatients).To(Equal(13))
 
 					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
 
@@ -2496,8 +2538,8 @@ var _ = Describe("TideReport", func() {
 					Expect(err).ToNot(HaveOccurred())
 					numResultCategories := 7
 					Expect(len(report.Results)).To(Equal(numResultCategories))
-					Expect(report.Metadata.CandidatePatients).To(Equal(9))
-					Expect(report.Metadata.SelectedPatients).To(Equal(9))
+					Expect(report.Metadata.CandidatePatients).To(Equal(11))
+					Expect(report.Metadata.SelectedPatients).To(Equal(11))
 
 					Expect(report.Results["timeInVeryLowPercent"]).To(tideResultsPatientMatcher(timeInVeryLowResults))
 
@@ -2526,8 +2568,8 @@ var _ = Describe("TideReport", func() {
 					Expect(err).ToNot(HaveOccurred())
 					numResultCategories := 2
 					Expect(len(report.Results)).To(Equal(numResultCategories))
-					Expect(report.Metadata.CandidatePatients).To(Equal(3))
-					Expect(report.Metadata.SelectedPatients).To(Equal(3))
+					Expect(report.Metadata.CandidatePatients).To(Equal(4))
+					Expect(report.Metadata.SelectedPatients).To(Equal(4))
 
 					timeCGMUsePercentResults = []patients.TideResultPatient{
 						// This patient would normally be put in the "timeInAnyLowPercentResults" category if using default categories, but since there are non-empty Categories params that don't include timeInAnyLowPercentResults, that user is put in the next available
@@ -2535,14 +2577,14 @@ var _ = Describe("TideReport", func() {
 							AverageGlucoseMmol: floatp(3.8945273631840798),
 							Patient: patients.TidePatient{
 								Email:       strp("time+in+low+4+pct@tidepool.org"),
-								FullName:    strp("Time below 3.9 mmol/L > 4%"),
+								FullName:    strp("Time below 3.9 mmol/L ≥ 4%"),
 								Id:          strp("aaaaaaaa-bbbb-cccc-dddd-aaaaaaaa4444"),
 								Tags:        []string{"aaaaaaaaaaaaaaaaaaaaaaaa"},
 								Reviews:     nil,
 								DataSources: nil,
 							},
 							TimeCGMUseMinutes:        intp(14070),
-							TimeCGMUsePercent:        floatp(0.6979166666666666),
+							TimeCGMUsePercent:        floatp(0.694),
 							TimeInHighPercent:        floatp(0),
 							TimeInLowPercent:         floatp(0.05472636815920398),
 							TimeInTargetPercent:      floatp(0.945273631840796),
@@ -2642,7 +2684,7 @@ var _ = Describe("TideReport", func() {
 							TimeInTargetPercent:      floatp(0.976303317535545),
 							TimeInTargetPercentDelta: floatp(0.022936733994397884),
 							TimeInVeryHighPercent:    floatp(0),
-							TimeInVeryLowPercent:     floatp(0.0074831628835120975),
+							TimeInVeryLowPercent:     floatp(0.0044831628835120975),
 							TimeInAnyHighPercent:     floatp(0.001995510102269893),
 							TimeInAnyLowPercent:      floatp(0.021701172362185085),
 							LastData:                 mustTime("2025-07-07T16:38:39.206Z"),
@@ -2657,7 +2699,7 @@ var _ = Describe("TideReport", func() {
 							AverageGlucoseMmol:       floatp(5.300278257324843),
 							TimeCGMUseMinutes:        intp(19625),
 							TimeCGMUsePercent:        floatp(0.9734623015873016),
-							TimeInHighPercent:        floatp(0.06929936305732484),
+							TimeInHighPercent:        floatp(0.02929936305732484),
 							TimeInLowPercent:         floatp(0.006878980891719746),
 							TimeInTargetPercent:      floatp(0.8991082802547771),
 							TimeInTargetPercentDelta: floatp(0.008514718886567851),
@@ -2724,7 +2766,7 @@ var _ = Describe("TideReport", func() {
 							TimeInTargetPercent:      floatp(0.976303317535545),
 							TimeInTargetPercentDelta: floatp(0.022936733994397884),
 							TimeInVeryHighPercent:    floatp(0),
-							TimeInVeryLowPercent:     floatp(0.0074831628835120975),
+							TimeInVeryLowPercent:     floatp(0.0044831628835120975),
 							TimeInAnyHighPercent:     floatp(0.001995510102269893),
 							TimeInAnyLowPercent:      floatp(0.021701172362185085),
 							LastData:                 mustTime("2025-07-07T16:38:39.206Z"),
@@ -2739,7 +2781,7 @@ var _ = Describe("TideReport", func() {
 							AverageGlucoseMmol:       floatp(5.300278257324843),
 							TimeCGMUseMinutes:        intp(19625),
 							TimeCGMUsePercent:        floatp(0.9734623015873016),
-							TimeInHighPercent:        floatp(0.06929936305732484),
+							TimeInHighPercent:        floatp(0.02929936305732484),
 							TimeInLowPercent:         floatp(0.006878980891719746),
 							TimeInTargetPercent:      floatp(0.8991082802547771),
 							TimeInTargetPercentDelta: floatp(0.008514718886567851),
@@ -2768,8 +2810,8 @@ var _ = Describe("TideReport", func() {
 					Expect(err).ToNot(HaveOccurred())
 					numResultCategories := 2
 					Expect(len(report.Results)).To(Equal(numResultCategories))
-					Expect(report.Metadata.CandidatePatients).To(Equal(4))
-					Expect(report.Metadata.SelectedPatients).To(Equal(4))
+					Expect(report.Metadata.CandidatePatients).To(Equal(5))
+					Expect(report.Metadata.SelectedPatients).To(Equal(5))
 
 					meetingTargetsResults = []patients.TideResultPatient{
 						{
@@ -2807,7 +2849,7 @@ var _ = Describe("TideReport", func() {
 							TimeInTargetPercent:      floatp(0.976303317535545),
 							TimeInTargetPercentDelta: floatp(0.022936733994397884),
 							TimeInVeryHighPercent:    floatp(0),
-							TimeInVeryLowPercent:     floatp(0.0074831628835120975),
+							TimeInVeryLowPercent:     floatp(0.0044831628835120975),
 							TimeInAnyHighPercent:     floatp(0.001995510102269893),
 							TimeInAnyLowPercent:      floatp(0.021701172362185085),
 							LastData:                 mustTime("2025-07-07T16:38:39.206Z"),
@@ -2822,7 +2864,7 @@ var _ = Describe("TideReport", func() {
 							AverageGlucoseMmol:       floatp(5.300278257324843),
 							TimeCGMUseMinutes:        intp(19625),
 							TimeCGMUsePercent:        floatp(0.9734623015873016),
-							TimeInHighPercent:        floatp(0.06929936305732484),
+							TimeInHighPercent:        floatp(0.02929936305732484),
 							TimeInLowPercent:         floatp(0.006878980891719746),
 							TimeInTargetPercent:      floatp(0.8991082802547771),
 							TimeInTargetPercentDelta: floatp(0.008514718886567851),

--- a/patients/repository/test/fixtures/patient_summaries.json
+++ b/patients/repository/test/fixtures/patient_summaries.json
@@ -3768,7 +3768,7 @@
                         "timeInVeryHighRecordsDelta": -12,
                         "timeInVeryLowMinutes": 150,
                         "timeInVeryLowMinutesDelta": 100,
-                        "timeInVeryLowPercent": 0.0074831628835120975,
+                        "timeInVeryLowPercent": 0.0044831628835120975,
                         "timeInVeryLowPercentDelta": 0.004989397297477185,
                         "timeInVeryLowRecords": 30,
                         "timeInVeryLowRecordsDelta": 20,
@@ -4178,13 +4178,13 @@
                         "timeInAnyLowRecordsDelta": 11,
                         "timeInExtremeHighMinutes": 175,
                         "timeInExtremeHighMinutesDelta": 175,
-                        "timeInExtremeHighPercent": 0.008917197452229299,
-                        "timeInExtremeHighPercentDelta": 0.008917197452229299,
+                        "timeInExtremeHighPercent": 0.002917197452229299,
+                        "timeInExtremeHighPercentDelta": 0.002917197452229299,
                         "timeInExtremeHighRecords": 35,
                         "timeInExtremeHighRecordsDelta": 35,
                         "timeInHighMinutes": 1360,
                         "timeInHighMinutesDelta": -400,
-                        "timeInHighPercent": 0.06929936305732484,
+                        "timeInHighPercent": 0.02929936305732484,
                         "timeInHighPercentDelta": -0.019231824065411574,
                         "timeInHighRecords": 272,
                         "timeInHighRecordsDelta": -80,
@@ -4579,7 +4579,7 @@
         "userId": "aaaaaaaa-bbbb-cccc-dddd-aaaaaaaa4444",
         "birthDate": "2000-01-01",
         "email": "time+in+low+4+pct@tidepool.org",
-        "fullName": "Time below 3.9 mmol/L > 4%",
+        "fullName": "Time below 3.9 mmol/L ≥ 4%",
         "mrn": null,
         "targetDevices": null,
         "tags":
@@ -4800,7 +4800,7 @@
                         "standardDeviationDelta": 0,
                         "timeCGMUseMinutes": 7035,
                         "timeCGMUseMinutesDelta": 0,
-                        "timeCGMUsePercent": 0.6979166666666666,
+                        "timeCGMUsePercent": 0.694,
                         "timeCGMUsePercentDelta": 0,
                         "timeCGMUseRecords": 1407,
                         "timeCGMUseRecordsDelta": 0,
@@ -4906,7 +4906,7 @@
                         "standardDeviationDelta": 0,
                         "timeCGMUseMinutes": 14070,
                         "timeCGMUseMinutesDelta": 0,
-                        "timeCGMUsePercent": 0.6979166666666666,
+                        "timeCGMUsePercent": 0.694,
                         "timeCGMUsePercentDelta": 0,
                         "timeCGMUseRecords": 2814,
                         "timeCGMUseRecordsDelta": 0,
@@ -5012,7 +5012,7 @@
                         "standardDeviationDelta": 0,
                         "timeCGMUseMinutes": 1005,
                         "timeCGMUseMinutesDelta": 0,
-                        "timeCGMUsePercent": 0.6979166666666666,
+                        "timeCGMUsePercent": 0.694,
                         "timeCGMUsePercentDelta": 0,
                         "timeCGMUseRecords": 201,
                         "timeCGMUseRecordsDelta": 0,
@@ -5069,7 +5069,7 @@
         "userId": "aaaaaaaa-bbbb-cccc-dddd-aaaaaa444444",
         "birthDate": "2000-01-01",
         "email": "time+in+low+4+pct+not+match+because+tags@tidepool.org",
-        "fullName": "Time below 3.9 mmol/L > 4% but not match tags",
+        "fullName": "Time below 3.9 mmol/L ≥ 4% but not match tags",
         "mrn": null,
         "targetDevices": null,
         "permissions":
@@ -7539,5 +7539,401 @@
                 }
             }
         }
+    },
+    {
+        "_id":
+        {
+            "$oid": "69f1d35dd6dc5fe5448bef46"
+        },
+        "clinicId":
+        {
+            "$oid": "cccccccccccccccccccccccc"
+        },
+        "userId": "aaaaaaaa-bbbb-cccc-dddd-dddddddddddd",
+        "birthDate": "2000-01-01",
+        "email": "rounded+very+low@tidepool.org",
+        "fullName": "Rounded Time In Very Low ≥ 1%",
+        "mrn": null,
+        "targetDevices": null,
+        "tags":
+        [
+            {
+                "$oid": "aaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        ],
+        "permissions":
+        {
+            "custodian":
+            {},
+            "view":
+            {},
+            "upload":
+            {},
+            "note":
+            {}
+        },
+        "createdTime":
+        {
+            "$date": "2025-07-03T22:08:40.937Z"
+        },
+        "updatedTime":
+        {
+            "$date": "2025-07-31T20:19:10.393Z"
+        },
+        "invitedBy": "aaaaaaaa-bbbb-cccc-dddd-bbbbbbbbbbbb",
+        "requireUniqueMrn": false,
+        "summary":
+        {
+            "cgmStats":
+            {
+                "id": "6866ffe94e48ffa6fbd23b49",
+                "config":
+                {
+                    "highGlucoseThreshold": 10,
+                    "lowGlucoseThreshold": 3.9,
+                    "schemaVersion": 6,
+                    "veryHighGlucoseThreshold": 13.9,
+                    "veryLowGlucoseThreshold": 3
+                },
+                "dates":
+                {
+                    "firstData":
+                    {
+                        "$date": "2025-06-06T22:09:07.079Z"
+                    },
+                    "hasFirstData": true,
+                    "hasLastData": true,
+                    "hasLastUploadDate": true,
+                    "hasOutdatedSince": false,
+                    "lastData":
+                    {
+                        "$date": "2025-07-04T14:49:07.079Z"
+                    },
+                    "lastUpdatedDate":
+                    {
+                        "$date": "2025-07-21T11:49:30.706Z"
+                    },
+                    "lastUpdatedReason":
+                    [
+                        "SCHEMA_MIGRATION"
+                    ],
+                    "lastUploadDate":
+                    {
+                        "$date": "2025-07-03T22:10:50.829Z"
+                    },
+                    "outdatedReason":
+                    []
+                },
+                "periods":
+                {
+                    "14d":
+                    {
+                        "averageDailyRecords": 201,
+                        "averageDailyRecordsDelta": 0,
+                        "averageGlucoseMmol": 2.681029437218411,
+                        "averageGlucoseMmolDelta": 0,
+                        "coefficientOfVariation": 0,
+                        "coefficientOfVariationDelta": 0,
+                        "daysWithData": 14,
+                        "daysWithDataDelta": 0,
+                        "hasAverageDailyRecords": true,
+                        "hasAverageGlucoseMmol": true,
+                        "hasGlucoseManagementIndicator": false,
+                        "hasTimeCGMUseMinutes": true,
+                        "hasTimeCGMUsePercent": true,
+                        "hasTimeCGMUseRecords": true,
+                        "hasTimeInAnyHighMinutes": false,
+                        "hasTimeInAnyHighPercent": true,
+                        "hasTimeInAnyHighRecords": false,
+                        "hasTimeInAnyLowMinutes": true,
+                        "hasTimeInAnyLowPercent": true,
+                        "hasTimeInAnyLowRecords": true,
+                        "hasTimeInExtremeHighMinutes": false,
+                        "hasTimeInExtremeHighPercent": true,
+                        "hasTimeInExtremeHighRecords": false,
+                        "hasTimeInHighMinutes": false,
+                        "hasTimeInHighPercent": true,
+                        "hasTimeInHighRecords": false,
+                        "hasTimeInLowMinutes": true,
+                        "hasTimeInLowPercent": true,
+                        "hasTimeInLowRecords": true,
+                        "hasTimeInTargetMinutes": true,
+                        "hasTimeInTargetPercent": true,
+                        "hasTimeInTargetRecords": true,
+                        "hasTimeInVeryHighMinutes": false,
+                        "hasTimeInVeryHighPercent": true,
+                        "hasTimeInVeryHighRecords": false,
+                        "hasTimeInVeryLowMinutes": false,
+                        "hasTimeInVeryLowPercent": true,
+                        "hasTimeInVeryLowRecords": false,
+                        "hasTotalRecords": true,
+                        "hoursWithData": 238,
+                        "hoursWithDataDelta": 0,
+                        "max": 3.9,
+                        "maxDelta": 0,
+                        "min": 3.8,
+                        "minDelta": 0,
+                        "standardDeviation": 0,
+                        "standardDeviationDelta": 0,
+                        "timeCGMUseMinutes": 14070,
+                        "timeCGMUseMinutesDelta": 0,
+                        "timeCGMUsePercent": 0.8839895693808708,
+                        "timeCGMUsePercentDelta": 0,
+                        "timeCGMUseRecords": 2814,
+                        "timeCGMUseRecordsDelta": 0,
+                        "timeInAnyHighMinutes": 0,
+                        "timeInAnyHighMinutesDelta": 0,
+                        "timeInAnyHighPercent": 0,
+                        "timeInAnyHighPercentDelta": 0,
+                        "timeInAnyHighRecords": 0,
+                        "timeInAnyHighRecordsDelta": 0,
+                        "timeInAnyLowMinutes": 770,
+                        "timeInAnyLowMinutesDelta": 0,
+                        "timeInAnyLowPercent": 0.095,
+                        "timeInAnyLowPercentDelta": 0,
+                        "timeInAnyLowRecords": 154,
+                        "timeInAnyLowRecordsDelta": 0,
+                        "timeInExtremeHighMinutes": 0,
+                        "timeInExtremeHighMinutesDelta": 0,
+                        "timeInExtremeHighPercent": 0,
+                        "timeInExtremeHighPercentDelta": 0,
+                        "timeInExtremeHighRecords": 0,
+                        "timeInExtremeHighRecordsDelta": 0,
+                        "timeInHighMinutes": 0,
+                        "timeInHighMinutesDelta": 0,
+                        "timeInHighPercent": 0,
+                        "timeInHighPercentDelta": 0,
+                        "timeInHighRecords": 0,
+                        "timeInHighRecordsDelta": 0,
+                        "timeInLowMinutes": 770,
+                        "timeInLowMinutesDelta": 0,
+                        "timeInLowPercent": 0.035,
+                        "timeInLowPercentDelta": 0,
+                        "timeInLowRecords": 154,
+                        "timeInLowRecordsDelta": 0,
+                        "timeInTargetMinutes": 13300,
+                        "timeInTargetMinutesDelta": 0,
+                        "timeInTargetPercent": 0.905,
+                        "timeInTargetPercentDelta": 0,
+                        "timeInTargetRecords": 2660,
+                        "timeInTargetRecordsDelta": 0,
+                        "timeInVeryHighMinutes": 0,
+                        "timeInVeryHighMinutesDelta": 0,
+                        "timeInVeryHighPercent": 0,
+                        "timeInVeryHighPercentDelta": 0,
+                        "timeInVeryHighRecords": 0,
+                        "timeInVeryHighRecordsDelta": 0,
+                        "timeInVeryLowMinutes": 0,
+                        "timeInVeryLowMinutesDelta": 0,
+                        "timeInVeryLowPercent": 0.06,
+                        "timeInVeryLowPercentDelta": 0,
+                        "timeInVeryLowRecords": 0,
+                        "timeInVeryLowRecordsDelta": 0,
+                        "totalRecords": 2814,
+                        "totalRecordsDelta": 0
+                    }
+                }
+            }
+        },
+        "reviews":
+        []
+    },
+    {
+        "_id":
+        {
+            "$oid": "69f1d88968445eed4625a569"
+        },
+        "clinicId":
+        {
+            "$oid": "cccccccccccccccccccccccc"
+        },
+        "userId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "birthDate": "2000-01-02",
+        "email": "time+in+rounded+low@tidepool.org",
+        "fullName": "Rounded Time In Low ≥ 4%",
+        "mrn": null,
+        "targetDevices": null,
+        "tags":
+        [
+            {
+                "$oid": "aaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        ],
+        "permissions":
+        {
+            "custodian":
+            {},
+            "view":
+            {},
+            "upload":
+            {},
+            "note":
+            {}
+        },
+        "createdTime":
+        {
+            "$date": "2025-07-03T22:08:40.937Z"
+        },
+        "updatedTime":
+        {
+            "$date": "2025-07-31T20:19:10.393Z"
+        },
+        "invitedBy": "aaaaaaaa-bbbb-cccc-dddd-bbbbbbbbbbbb",
+        "requireUniqueMrn": false,
+        "summary":
+        {
+            "cgmStats":
+            {
+                "id": "6866ffe94e48ffa6fbd23b49",
+                "config":
+                {
+                    "highGlucoseThreshold": 10,
+                    "lowGlucoseThreshold": 3.9,
+                    "schemaVersion": 6,
+                    "veryHighGlucoseThreshold": 13.9,
+                    "veryLowGlucoseThreshold": 3
+                },
+                "dates":
+                {
+                    "firstData":
+                    {
+                        "$date": "2025-06-06T22:09:07.079Z"
+                    },
+                    "hasFirstData": true,
+                    "hasLastData": true,
+                    "hasLastUploadDate": true,
+                    "hasOutdatedSince": false,
+                    "lastData":
+                    {
+                        "$date": "2025-07-05T15:50:07.000Z"
+                    },
+                    "lastUpdatedDate":
+                    {
+                        "$date": "2025-07-21T11:49:30.706Z"
+                    },
+                    "lastUpdatedReason":
+                    [
+                        "SCHEMA_MIGRATION"
+                    ],
+                    "lastUploadDate":
+                    {
+                        "$date": "2025-07-03T22:10:50.829Z"
+                    },
+                    "outdatedReason":
+                    []
+                },
+                "periods":
+                {
+                    "14d":
+                    {
+                        "averageDailyRecords": 201,
+                        "averageDailyRecordsDelta": 0,
+                        "averageGlucoseMmol": 3.9782035652530548,
+                        "averageGlucoseMmolDelta": 0,
+                        "coefficientOfVariation": 0,
+                        "coefficientOfVariationDelta": 0,
+                        "daysWithData": 14,
+                        "daysWithDataDelta": 0,
+                        "hasAverageDailyRecords": true,
+                        "hasAverageGlucoseMmol": true,
+                        "hasGlucoseManagementIndicator": false,
+                        "hasTimeCGMUseMinutes": true,
+                        "hasTimeCGMUsePercent": true,
+                        "hasTimeCGMUseRecords": true,
+                        "hasTimeInAnyHighMinutes": false,
+                        "hasTimeInAnyHighPercent": true,
+                        "hasTimeInAnyHighRecords": false,
+                        "hasTimeInAnyLowMinutes": true,
+                        "hasTimeInAnyLowPercent": true,
+                        "hasTimeInAnyLowRecords": true,
+                        "hasTimeInExtremeHighMinutes": false,
+                        "hasTimeInExtremeHighPercent": true,
+                        "hasTimeInExtremeHighRecords": false,
+                        "hasTimeInHighMinutes": false,
+                        "hasTimeInHighPercent": true,
+                        "hasTimeInHighRecords": false,
+                        "hasTimeInLowMinutes": true,
+                        "hasTimeInLowPercent": true,
+                        "hasTimeInLowRecords": true,
+                        "hasTimeInTargetMinutes": true,
+                        "hasTimeInTargetPercent": true,
+                        "hasTimeInTargetRecords": true,
+                        "hasTimeInVeryHighMinutes": false,
+                        "hasTimeInVeryHighPercent": true,
+                        "hasTimeInVeryHighRecords": false,
+                        "hasTimeInVeryLowMinutes": false,
+                        "hasTimeInVeryLowPercent": true,
+                        "hasTimeInVeryLowRecords": false,
+                        "hasTotalRecords": true,
+                        "hoursWithData": 238,
+                        "hoursWithDataDelta": 0,
+                        "max": 3.9,
+                        "maxDelta": 0,
+                        "min": 3.8,
+                        "minDelta": 0,
+                        "standardDeviation": 0,
+                        "standardDeviationDelta": 0,
+                        "timeCGMUseMinutes": 14070,
+                        "timeCGMUseMinutesDelta": 0,
+                        "timeCGMUsePercent": 0.7625795277794299,
+                        "timeCGMUsePercentDelta": 0,
+                        "timeCGMUseRecords": 2814,
+                        "timeCGMUseRecordsDelta": 0,
+                        "timeInAnyHighMinutes": 0,
+                        "timeInAnyHighMinutesDelta": 0,
+                        "timeInAnyHighPercent": 0,
+                        "timeInAnyHighPercentDelta": 0,
+                        "timeInAnyHighRecords": 0,
+                        "timeInAnyHighRecordsDelta": 0,
+                        "timeInAnyLowMinutes": 770,
+                        "timeInAnyLowMinutesDelta": 0,
+                        "timeInAnyLowPercent": 0.043,
+                        "timeInAnyLowPercentDelta": 0,
+                        "timeInAnyLowRecords": 154,
+                        "timeInAnyLowRecordsDelta": 0,
+                        "timeInExtremeHighMinutes": 0,
+                        "timeInExtremeHighMinutesDelta": 0,
+                        "timeInExtremeHighPercent": 0,
+                        "timeInExtremeHighPercentDelta": 0,
+                        "timeInExtremeHighRecords": 0,
+                        "timeInExtremeHighRecordsDelta": 0,
+                        "timeInHighMinutes": 0,
+                        "timeInHighMinutesDelta": 0,
+                        "timeInHighPercent": 0,
+                        "timeInHighPercentDelta": 0,
+                        "timeInHighRecords": 0,
+                        "timeInHighRecordsDelta": 0,
+                        "timeInLowMinutes": 770,
+                        "timeInLowMinutesDelta": 0,
+                        "timeInLowPercent": 0.039,
+                        "timeInLowPercentDelta": 0,
+                        "timeInLowRecords": 154,
+                        "timeInLowRecordsDelta": 0,
+                        "timeInTargetMinutes": 13300,
+                        "timeInTargetMinutesDelta": 0,
+                        "timeInTargetPercent": 0.957,
+                        "timeInTargetPercentDelta": 0,
+                        "timeInTargetRecords": 2660,
+                        "timeInTargetRecordsDelta": 0,
+                        "timeInVeryHighMinutes": 0,
+                        "timeInVeryHighMinutesDelta": 0,
+                        "timeInVeryHighPercent": 0,
+                        "timeInVeryHighPercentDelta": 0,
+                        "timeInVeryHighRecords": 0,
+                        "timeInVeryHighRecordsDelta": 0,
+                        "timeInVeryLowMinutes": 0,
+                        "timeInVeryLowMinutesDelta": 0,
+                        "timeInVeryLowPercent": 0.004,
+                        "timeInVeryLowPercentDelta": 0,
+                        "timeInVeryLowRecords": 0,
+                        "timeInVeryLowRecordsDelta": 0,
+                        "totalRecords": 2814,
+                        "totalRecordsDelta": 0
+                    }
+                }
+            }
+        },
+        "reviews":
+        []
     }
 ]


### PR DESCRIPTION
Updates the TIDE report query predicates to query on rounded percents and be inclusive thresholds instead of exclusive. See comments in code for more details.