### PR TITLE
adjust test clinic site name generation to prevent a flappy test

### DIFF
--- a/sites/test/sites.go
+++ b/sites/test/sites.go
@@ -1,30 +1,24 @@
 package test
 
 import (
+	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/tidepool-org/clinic/sites"
-	"github.com/tidepool-org/clinic/test"
 )
 
 func Random() sites.Site {
-	id := primitive.NewObjectID()
-	name := test.Faker.Lorem().Word()
 	return sites.Site{
-		Name: name,
-		Id:   id,
+		Id: primitive.NewObjectID(),
+		// This should be random enough to be unique, see the Godoc for the odds.
+		Name: uuid.NewString(),
 	}
 }
 
 func RandomSlice(n int) []sites.Site {
-	uniqNames := make(map[string]struct{})
 	sites := make([]sites.Site, 0, n)
 	for len(sites) < n {
-		s := Random()
-		if _, found := uniqNames[s.Name]; !found {
-			uniqNames[s.Name] = struct{}{}
-			sites = append(sites, s)
-		}
+		sites = append(sites, Random())
 	}
 	return sites
 }


### PR DESCRIPTION
Previously we used the Faker library's Lorem package to generate a word to use as a site name. However I didn't include enough uniqueness protection to prevent the tests from occasionally flapping, especially for tests that use a large number of site names (like those testing boundary conditions). I'm switching the site names to be UUIDv4 strings, which while not as readable, have much much lower probabilities of generating duplicates and thereby causing a flappy test.