### PR TITLE
permit backend services to suppress notifications

### DIFF
--- a/auth/authorizer_test.go
+++ b/auth/authorizer_test.go
@@ -671,6 +671,60 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
+		It("allows backend services to suppress notifications", func() {
+			input := map[string]interface{}{
+				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "suppressed_notifications"},
+				"method": "POST",
+				"auth": map[string]interface{}{
+					"subjectId":    "clinic-worker",
+					"serverAccess": true,
+				},
+			}
+			err := authorizer.EvaluatePolicy(context.Background(), input)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("allows clinic admins to suppress notifications", func() {
+			input := map[string]interface{}{
+				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "suppressed_notifications"},
+				"method": "POST",
+				"auth": map[string]interface{}{
+					"subjectId":    "1234567890",
+					"serverAccess": false,
+				},
+				"clinician": clinicAdmin,
+			}
+			err := authorizer.EvaluatePolicy(context.Background(), input)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("prevents clinic members from suppressing notifications", func() {
+			input := map[string]interface{}{
+				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "suppressed_notifications"},
+				"method": "POST",
+				"auth": map[string]interface{}{
+					"subjectId":    "1234567890",
+					"serverAccess": false,
+				},
+				"clinician": clinicMember,
+			}
+			err := authorizer.EvaluatePolicy(context.Background(), input)
+			Expect(err).To(Equal(auth.ErrUnauthorized))
+		})
+
+		It("prevents users from suppressing notifications", func() {
+			input := map[string]interface{}{
+				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "suppressed_notifications"},
+				"method": "POST",
+				"auth": map[string]interface{}{
+					"subjectId":    "1234567890",
+					"serverAccess": false,
+				},
+			}
+			err := authorizer.EvaluatePolicy(context.Background(), input)
+			Expect(err).To(Equal(auth.ErrUnauthorized))
+		})
+
 		It("prevents users from triggering deletion", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "users", "1234567890", "clinics"},

--- a/auth/authorizer_test.go
+++ b/auth/authorizer_test.go
@@ -5,8 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidepool-org/clinic/auth"
 	"go.uber.org/zap"
+
+	"github.com/tidepool-org/clinic/auth"
 )
 
 var clinicAdmin = map[string]interface{}{
@@ -144,7 +145,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows ORCA to update a clinician", func() {
+		It("allows ORCA to update a clinician", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "clinicians", "12345"},
 				"method": "PUT",
@@ -157,7 +158,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows ORCA to delete a clinician", func() {
+		It("allows ORCA to delete a clinician", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "clinicians", "12345"},
 				"method": "DELETE",
@@ -345,7 +346,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinicians to list clinics they are a member of", func() {
+		It("allows clinicians to list clinics they are a member of", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinicians", "1234567890", "clinics"},
 				"method": "GET",
@@ -358,7 +359,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic admins to delete clinics", func() {
+		It("allows clinic admins to delete clinics", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64"},
 				"method": "DELETE",
@@ -372,7 +373,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it doesn't allow clinic members to delete clinics", func() {
+		It("doesn't allow clinic members to delete clinics", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64"},
 				"method": "DELETE",
@@ -386,7 +387,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it allows clinic admins to update patients", func() {
+		It("allows clinic admins to update patients", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "99c290f838"},
 				"method": "PUT",
@@ -400,7 +401,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic members to update patients", func() {
+		It("allows clinic members to update patients", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "99c290f838"},
 				"method": "PUT",
@@ -414,7 +415,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic admins to create custodial accounts for patients", func() {
+		It("allows clinic admins to create custodial accounts for patients", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients"},
 				"method": "POST",
@@ -428,7 +429,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic-worker to create custodial accounts for patients", func() {
+		It("allows clinic-worker to create custodial accounts for patients", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients"},
 				"method": "POST",
@@ -441,7 +442,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic members to create custodial accounts for patients", func() {
+		It("allows clinic members to create custodial accounts for patients", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients"},
 				"method": "POST",
@@ -455,7 +456,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows currently authenticated clinic member to delete their own profile", func() {
+		It("allows currently authenticated clinic member to delete their own profile", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "clinicians", "1234567890"},
 				"method": "DELETE",
@@ -469,7 +470,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it prevents currently authenticated clinic member to delete profiles of other clinicians", func() {
+		It("prevents currently authenticated clinic member to delete profiles of other clinicians", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "clinicians", "99999999"},
 				"method": "DELETE",
@@ -483,7 +484,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it prevents clinicians to list clinics of other users", func() {
+		It("prevents clinicians to list clinics of other users", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinicians", "123456789", "clinics"},
 				"method": "GET",
@@ -496,7 +497,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it allows hydrophone to update invited clinicians", func() {
+		It("allows hydrophone to update invited clinicians", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "invites", "clinicians", "gw94dmVOaB4CH", "clinician"},
 				"method": "PATCH",
@@ -509,7 +510,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows hydrophone to retrieve invited clinicians", func() {
+		It("allows hydrophone to retrieve invited clinicians", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "invites", "clinicians", "gw94dmVOaB4CH", "clinician"},
 				"method": "GET",
@@ -522,7 +523,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows hydrophone to delete invited clinicians", func() {
+		It("allows hydrophone to delete invited clinicians", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "invites", "clinicians", "gw94dmVOaB4CH", "clinician"},
 				"method": "DELETE",
@@ -535,7 +536,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows orca to fetch migrations by id", func() {
+		It("allows orca to fetch migrations by id", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "migrations", "123456789"},
 				"method": "GET",
@@ -548,7 +549,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic-worker to fetch migrations by id", func() {
+		It("allows clinic-worker to fetch migrations by id", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "migrations", "123456789"},
 				"method": "GET",
@@ -561,7 +562,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinicians to fetch their own migrations", func() {
+		It("allows clinicians to fetch their own migrations", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "migrations", "1234567890"},
 				"method": "GET",
@@ -575,7 +576,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows clinic-worker to update migrations", func() {
+		It("allows clinic-worker to update migrations", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "migrations", "1234567890"},
 				"method": "PATCH",
@@ -589,7 +590,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it prevents clinicians to update their own migrations", func() {
+		It("prevents clinicians to update their own migrations", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "migrations", "1234567890"},
 				"method": "PATCH",
@@ -603,7 +604,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it allows clinic-worker to delete user accounts", func() {
+		It("allows clinic-worker to delete user accounts", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "users", "1234567890", "clinics"},
 				"method": "DELETE",
@@ -616,7 +617,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it allows orca to update clinic service tier", func() {
+		It("allows orca to update clinic service tier", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "tier"},
 				"method": "POST",
@@ -629,7 +630,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("it prevents members to update clinic service tier", func() {
+		It("prevents members to update clinic service tier", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "tier"},
 				"method": "POST",
@@ -643,7 +644,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it prevents admins to update clinic service tier", func() {
+		It("prevents admins to update clinic service tier", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "tier"},
 				"method": "POST",
@@ -657,7 +658,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it prevents users to update clinic service tier", func() {
+		It("prevents users to update clinic service tier", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "tier"},
 				"method": "POST",
@@ -670,7 +671,7 @@ var _ = Describe("Request Authorizer", func() {
 			Expect(err).To(Equal(auth.ErrUnauthorized))
 		})
 
-		It("it prevents users from triggering deletion", func() {
+		It("prevents users from triggering deletion", func() {
 			input := map[string]interface{}{
 				"path":   []string{"v1", "users", "1234567890", "clinics"},
 				"method": "DELETE",
@@ -684,7 +685,7 @@ var _ = Describe("Request Authorizer", func() {
 		})
 	})
 
-	It("it allows currently authenticated clinic member to create patient tags", func() {
+	It("allows currently authenticated clinic member to create patient tags", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patient_tags"},
 			"method": "POST",
@@ -698,7 +699,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows currently authenticated clinic member to update patient tags", func() {
+	It("allows currently authenticated clinic member to update patient tags", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patient_tags", "6066fbabc6f484277200ac65"},
 			"method": "PUT",
@@ -712,7 +713,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows currently authenticated clinic admin to delete patient tags", func() {
+	It("allows currently authenticated clinic admin to delete patient tags", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patient_tags", "6066fbabc6f484277200ac65"},
 			"method": "DELETE",
@@ -726,7 +727,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents currently authenticated clinic non-admin member from deleting patient tags", func() {
+	It("prevents currently authenticated clinic non-admin member from deleting patient tags", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patient_tags", "6066fbabc6f484277200ac65"},
 			"method": "DELETE",
@@ -740,7 +741,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows clinic-worker to remove a tag from all matching patients", func() {
+	It("allows clinic-worker to remove a tag from all matching patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "delete_tag", "6066fbabc6f484277200ac65"},
 			"method": "POST",
@@ -753,7 +754,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows a currently authenticated clinic admin member to remove a tag from all matching patients", func() {
+	It("allows a currently authenticated clinic admin member to remove a tag from all matching patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "delete_tag", "6066fbabc6f484277200ac65"},
 			"method": "POST",
@@ -767,7 +768,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents a currently authenticated clinic non-admin member from removing a tag from all matching patients", func() {
+	It("prevents a currently authenticated clinic non-admin member from removing a tag from all matching patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "delete_tag", "6066fbabc6f484277200ac65"},
 			"method": "POST",
@@ -781,7 +782,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("it allows clinic-worker to assign a tag to all matching patients", func() {
+	It("allows clinic-worker to assign a tag to all matching patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "assign_tag", "6066fbabc6f484277200ac65"},
 			"method": "POST",
@@ -794,7 +795,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows a currently authenticated clinic admin member to assign a tag to all matching patients", func() {
+	It("allows a currently authenticated clinic admin member to assign a tag to all matching patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "assign_tag", "6066fbabc6f484277200ac65"},
 			"method": "POST",
@@ -808,7 +809,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents a currently authenticated clinic non-admin member from assigning a tag to all matching patients", func() {
+	It("prevents a currently authenticated clinic non-admin member from assigning a tag to all matching patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patients", "assign_tag", "6066fbabc6f484277200ac65"},
 			"method": "POST",
@@ -822,7 +823,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("it allows ORCA to list membership restrictions", func() {
+	It("allows ORCA to list membership restrictions", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "membership_restrictions"},
 			"method": "GET",
@@ -835,7 +836,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows clinic admins to list membership restrictions", func() {
+	It("allows clinic admins to list membership restrictions", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "membership_restrictions"},
 			"method": "GET",
@@ -849,7 +850,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinic members to list membership restrictions", func() {
+	It("prevents clinic members to list membership restrictions", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "membership_restrictions"},
 			"method": "GET",
@@ -863,7 +864,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows ORCA to update membership restrictions", func() {
+	It("allows ORCA to update membership restrictions", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "membership_restrictions"},
 			"method": "PUT",
@@ -876,7 +877,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinic admins to update membership restrictions", func() {
+	It("prevents clinic admins to update membership restrictions", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "membership_restrictions"},
 			"method": "PUT",
@@ -890,7 +891,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it prevents clinic members to update membership restrictions", func() {
+	It("prevents clinic members to update membership restrictions", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "membership_restrictions"},
 			"method": "PUT",
@@ -904,7 +905,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows ORCA to fetch ehr settings", func() {
+	It("allows ORCA to fetch ehr settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "ehr"},
 			"method": "GET",
@@ -917,7 +918,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows ORCA to update ehr settings", func() {
+	It("allows ORCA to update ehr settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "ehr"},
 			"method": "PUT",
@@ -930,7 +931,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinic members to update ehr settings", func() {
+	It("prevents clinic members to update ehr settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "ehr"},
 			"method": "PUT",
@@ -944,7 +945,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows clinic members to fetch ehr settings", func() {
+	It("allows clinic members to fetch ehr settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "ehr"},
 			"method": "GET",
@@ -958,7 +959,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows ORCA to fetch mrn settings", func() {
+	It("allows ORCA to fetch mrn settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "mrn"},
 			"method": "GET",
@@ -971,7 +972,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows ORCA to add a service account to a clinic", func() {
+	It("allows ORCA to add a service account to a clinic", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "service_accounts"},
 			"method": "POST",
@@ -984,7 +985,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinic admins to add service accounts", func() {
+	It("prevents clinic admins to add service accounts", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "service_accounts"},
 			"method": "POST",
@@ -998,7 +999,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows clinic members to fetch mrn settings", func() {
+	It("allows clinic members to fetch mrn settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "mrn"},
 			"method": "GET",
@@ -1012,7 +1013,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows ORCA to update mrn settings", func() {
+	It("allows ORCA to update mrn settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "mrn"},
 			"method": "PUT",
@@ -1025,7 +1026,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinic members to update mrn settings", func() {
+	It("prevents clinic members to update mrn settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "mrn"},
 			"method": "PUT",
@@ -1039,7 +1040,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows ORCA to fetch patient count settings", func() {
+	It("allows ORCA to fetch patient count settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "patient_count"},
 			"method": "GET",
@@ -1052,7 +1053,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows clinic members to fetch patient count settings", func() {
+	It("allows clinic members to fetch patient count settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "patient_count"},
 			"method": "GET",
@@ -1066,7 +1067,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows ORCA to update patient count settings", func() {
+	It("allows ORCA to update patient count settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "patient_count"},
 			"method": "PUT",
@@ -1079,7 +1080,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinic members to update patient count settings", func() {
+	It("prevents clinic members to update patient count settings", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "settings", "patient_count"},
 			"method": "PUT",
@@ -1093,7 +1094,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows ORCA to fetch patient count", func() {
+	It("allows ORCA to fetch patient count", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patient_count"},
 			"method": "GET",
@@ -1106,7 +1107,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows clinic members to fetch patient count", func() {
+	It("allows clinic members to fetch patient count", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "patient_count"},
 			"method": "GET",
@@ -1120,7 +1121,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows clinic worker to match patients", func() {
+	It("allows clinic worker to match patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "redox", "match"},
 			"method": "POST",
@@ -1133,7 +1134,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows task service to sync clinic patients", func() {
+	It("allows task service to sync clinic patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "ehr", "sync"},
 			"method": "POST",
@@ -1146,7 +1147,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows task service to sync patients", func() {
+	It("allows task service to sync patients", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "patients", "012345678890", "ehr", "sync"},
 			"method": "POST",
@@ -1159,7 +1160,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it allows users to fetch list of patients they have access to", func() {
+	It("allows users to fetch list of patients they have access to", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "patients"},
 			"method": "GET",
@@ -1172,7 +1173,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it prevents clinicians from generating merge reports", func() {
+	It("prevents clinicians from generating merge reports", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "reports", "merge"},
 			"method": "POST",
@@ -1186,7 +1187,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it prevents users from generating merge reports", func() {
+	It("prevents users from generating merge reports", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "reports", "merge"},
 			"method": "POST",
@@ -1199,7 +1200,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows orca to generate merge reports", func() {
+	It("allows orca to generate merge reports", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "reports", "merge"},
 			"method": "POST",
@@ -1277,7 +1278,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).To(Equal(auth.ErrUnauthorized))
 	})
 
-	It("it allows orca to merge clinics", func() {
+	It("allows orca to merge clinics", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "merge"},
 			"method": "POST",
@@ -1290,7 +1291,7 @@ var _ = Describe("Request Authorizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("it doesn't allow clinic admins to merge clinics", func() {
+	It("doesn't allow clinic admins to merge clinics", func() {
 		input := map[string]interface{}{
 			"path":   []string{"v1", "clinics", "6066fbabc6f484277200ac64", "merge"},
 			"method": "POST",

--- a/auth/policy.rego
+++ b/auth/policy.rego
@@ -206,12 +206,20 @@ allow {
   input.path = ["v1", "clinics", _, "reports", "merge"]
 }
 
-# Allow backend services to update clinic tiers
+# Allow currently authenticated clinician to suppress notifications
 # POST /v1/clinics/:clinicId/suppressed_notifications
 allow {
   input.method == "POST"
   input.path = ["v1", "clinics", _, "suppressed_notifications"]
   clinician_has_write_access
+}
+
+# Allow backend services to suppress notifications
+# POST /v1/clinics/:clinicId/suppressed_notifications
+allow {
+  is_backend_service
+  input.method == "POST"
+  input.path = ["v1", "clinics", _, "suppressed_notifications"]
 }
 
 # Allow backend services to add service accounts to clinics


### PR DESCRIPTION
The first commit is just cleanup of test names.

The second commit is the (small) fix.

BACK-4174